### PR TITLE
Refactor GenoML munging code

### DIFF
--- a/genoml/cli/munging.py
+++ b/genoml/cli/munging.py
@@ -13,74 +13,96 @@
 # limitations under the License.
 # ==============================================================================
 
-import argparse
 import sys
 
 import genoml.dependencies
 from genoml import preprocessing
 
 
-def main(prefix, impute, geno, skip_prune, r2_cutoff, pheno, addit, feature_selection, gwas, p, vif, iter, ref_cols_harmonize, umap_reduce, adjust_data, adjust_normalize, target_features, confounders, data_type):
+def main(
+    run_prefix,
+    impute_type,
+    geno_path,
+    prune_choice,
+    r2_cutoff,
+    pheno_path,
+    addit_path,
+    n_est,
+    gwas_path,
+    p_gwas,
+    vif_thresh,
+    vif_iter,
+    ref_cols_harmonize,
+    umap_reduce,
+    adjust_data,
+    adjust_normalize,
+    target_features,
+    confounders,
+    data_type,
+):
     genoml.dependencies.check_dependencies()
 
-    run_prefix = prefix
-    impute_type = impute
-    geno_path = geno
-    prune_choice = skip_prune
-    pheno_path = pheno
-    addit_path = addit
-    n_est = feature_selection
-    gwas_path = gwas
-    p_gwas = p
-    r2_cutoff = r2_cutoff
-    vif_thresh = vif
-    vif_iter = iter
-    refColsHarmonize = ref_cols_harmonize
-    umap_reduce = umap_reduce
-    adjust_data = adjust_data
-    adjust_normalize = adjust_normalize
-    target_features = target_features
-    confounders = confounders
-
     # Print configurations
-    print("")
-    print("Here is some basic info on the command you are about to run.")
-    print("Python version info...")
-    print(sys.version)
-    print("CLI argument info...")
     print(
-        f"The output prefix for this run is {run_prefix} and will be appended to later runs of GenoML.")
-    print(f"Working with genotype data? {geno_path}")
-    print(f"Do you want GenoML to prune your SNPs for you? {prune_choice}")
-    print(f"The pruning threshold you've chosen is {r2_cutoff}")
-    print(f"Working with additional predictors? {addit_path}")
-    print(f"Where is your phenotype file? {pheno_path}")
-    print(f"Any use for an external set of GWAS summary stats? {gwas_path}")
-    print(
-        f"If you plan on using external GWAS summary stats for SNP filtering, we'll only keep SNPs at what P value? {p_gwas}")
-    print(f"How strong is your VIF filter? {vif_thresh}")
-    print(f"How many iterations of VIF filtering are you doing? {vif_iter}")
-    print(
-        f"The imputation method you picked is using the column {impute_type} to fill in any remaining NAs.")
-    print(f"Will you be adjusting additional features using UMAP dimensionality reduction? {umap_reduce}")
-    print(
-        "Give credit where credit is due, for this stage of analysis we use code from the great contributors to python packages: os, sys, argparse, numpy, pandas, joblib, math and time. We also use PLINK v1.9 from https://www.cog-genomics.org/plink/1.9/.")
-    print("")
+        "\n"
+        "Here is some basic info on the command you are about to run.\n"
+        "Python version info...\n"
+        f"{sys.version}\n"
+        "CLI argument info...\n"
+        f"The output prefix for this run is {run_prefix} and will be appended to later "
+        "runs of GenoML.\n"
+        f"Genotype Path: {geno_path}\n"
+        f"Plink pruning: {prune_choice}\n"
+        f"Pruning threshold: {r2_cutoff}\n"
+        f"Additional feature path: {addit_path}\n"
+        f"Phenotype path: {pheno_path}\n"
+        f"GWAS summary set path: {gwas_path}\n"
+        f"GWAS p value threshold: {p_gwas}\n"
+        f"Vif threshold strength: {vif_thresh}\n"
+        f"Vif iterations: {vif_iter}\n"
+        f"Imputation method to fill NAs: {impute_type}\n"
+        f"Will you be adjusting additional features using UMAP dimensionality "
+        f"reduction? {umap_reduce}\n"
+        "Give credit where credit is due, for this stage of analysis we use code "
+        "from the great contributors to python packages: os, sys, argparse, numpy, "
+        "pandas, joblib, math and time. We also use PLINK v1.9 "
+        "from https://www.cog-genomics.org/plink/1.9/.\n"
+        "\n"
+    )
 
     # Run the munging script in genoml.preprocessing
-    munger = preprocessing.munging(pheno_path=pheno_path, run_prefix=run_prefix, impute_type=impute_type, skip_prune=prune_choice,
-                     p_gwas=p_gwas, addit_path=addit_path, gwas_path=gwas_path, geno_path=geno_path, refColsHarmonize=refColsHarmonize, r2_cutoff=r2_cutoff)
+    munger = preprocessing.Munging(
+        pheno_path=pheno_path,
+        run_prefix=run_prefix,
+        impute_type=impute_type,
+        skip_prune=prune_choice,
+        p_gwas=p_gwas,
+        addit_path=addit_path,
+        gwas_path=gwas_path,
+        geno_path=geno_path,
+        refColsHarmonize=ref_cols_harmonize,
+        r2_cutoff=r2_cutoff,
+    )
 
     # Process the PLINK inputs (for pruning)
     df = munger.plink_inputs()
+    del munger
 
-    # Run the UMAP dimension reduction/ adjuster 
-    if (adjust_data == "yes" or umap_reduce == "yes"):
-        adjuster = preprocessing.adjuster(run_prefix, df, target_features, confounders, adjust_data, adjust_normalize, umap_reduce)
+    # Run the UMAP dimension reduction/ adjuster
+    if adjust_data == "yes" or umap_reduce == "yes":
+        adjuster = preprocessing.adjuster(
+            run_prefix,
+            df,
+            target_features,
+            confounders,
+            adjust_data,
+            adjust_normalize,
+            umap_reduce,
+        )
         reduced_df = adjuster.umap_reducer()
-        if (adjust_data == "yes"): 
+        if adjust_data == "yes":
             print(f"\n You have chosen to adjust your data! \n")
-            if (adjust_normalize == "yes"):
+            if adjust_normalize == "yes":
                 print(f"\n You have also chosen to normalize your adjusted data \n")
             else:
                 print(f"\n You have also chosen NOT to normalize your adjusted data \n")
@@ -88,7 +110,9 @@ def main(prefix, impute, geno, skip_prune, r2_cutoff, pheno, addit, feature_sele
 
     # Run the feature selection using extraTrees
     if n_est > 0:
-        featureSelection_df = preprocessing.featureselection(run_prefix, df, data_type, n_est)
+        featureSelection_df = preprocessing.featureselection(
+            run_prefix, df, data_type, n_est
+        )
         df = featureSelection_df.rank()
         featureSelection_df.export_data()
 

--- a/genoml/preprocessing/__init__.py
+++ b/genoml/preprocessing/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-from genoml.preprocessing.munging import munging
+from genoml.preprocessing.munging import Munging
 from genoml.preprocessing.vif import vif
 from genoml.preprocessing.featureselection import featureselection
 from genoml.preprocessing.harmonizing import harmonizing

--- a/genoml/preprocessing/munging.py
+++ b/genoml/preprocessing/munging.py
@@ -15,340 +15,363 @@
 
 # Import the necessary packages
 import subprocess
-import sys
+from typing import List, Optional, Tuple
+
 import numpy as np
 import pandas as pd
 from pandas_plink import read_plink1_bin
+from scipy import stats
 
 # Define the munging class
 import genoml.dependencies
 
-class munging:
-    def __init__(self, pheno_path, run_prefix="GenoML_data", impute_type="median", skip_prune="no", p_gwas=0.001, addit_path=None, gwas_path=None, geno_path=None, refColsHarmonize=None, r2_cutoff="0.5"):
+
+class Munging(object):
+    def __init__(
+        self,
+        pheno_path: str,
+        run_prefix="GenoML_data",
+        impute_type="median",
+        skip_prune="no",
+        p_gwas: float = 0.001,
+        addit_path: Optional[str] = None,
+        gwas_path: Optional[str] = None,
+        geno_path: Optional[str] = None,
+        refColsHarmonize=None,
+        r2_cutoff="0.5",
+    ):
         self.pheno_path = pheno_path
         self.run_prefix = run_prefix
-        
+
+        if impute_type not in ["mean", "median"]:
+            # Currently only supports mean and median
+            raise ValueError(
+                "The 2 types of imputation currently supported are 'mean' and 'median'"
+            )
         self.impute_type = impute_type
         self.p_gwas = p_gwas
-        
-        self.addit_path = addit_path
-        self.gwas_path = gwas_path
-        self.geno_path = geno_path
 
         self.r2 = r2_cutoff
 
-        self.skip_prune = skip_prune
-        
+        if skip_prune == "no":
+            self.skip_prune = False
+        elif skip_prune == "yes":
+            self.skip_prune = True
+        else:
+            raise ValueError(
+                f'`skip_prune` should be one of "yes" or "no", not {skip_prune}'
+            )
+
         self.refColsHarmonize = refColsHarmonize
 
-        # Reading in the phenotype file 
-        self.pheno_df = pd.read_csv(pheno_path, engine='c')
-        
+        # Reading in the phenotype file
+        self.pheno_df = pd.read_csv(pheno_path, engine="c")
+
         # Raise an error and exit if the phenotype file is not properly formatted
-        try:
-            if set(['ID','PHENO']).issubset(self.pheno_df.columns) == False:
-                raise ValueError("""
-                Error: It doesn't look as though your phenotype file is properly formatted. 
-                Did you check that the columns are 'ID' and 'PHENO' and that controls=0 and cases=1?""")
-        except ValueError as ve:
-            print(ve)
-            sys.exit()
+        if not {"ID", "PHENO"}.issubset(self.pheno_df.columns):
+            raise ValueError(
+                "Error: It doesn't look as though your phenotype file is properly "
+                "formatted.\n"
+                "Did you check that the columns are 'ID' and 'PHENO' and that "
+                "controls=0 and cases=1?"
+            )
 
-        # Typecase to read in the ID column as a string and the PHENO as an integer
-        self.pheno_df['ID'] = self.pheno_df['ID'].astype(str)
-        self.pheno_df['PHENO'] = self.pheno_df['PHENO'].astype(int)
+        # # Typecase to read in the ID column as a string and the PHENO as an integer
+        self.pheno_df["ID"] = self.pheno_df["ID"].astype(str)
+        self.pheno_df["PHENO"] = self.pheno_df["PHENO"].astype(int)
 
-        if (addit_path==None):
+        self.addit_path = addit_path
+        self.gwas_path = gwas_path
+        self.geno_path = geno_path
+        if not addit_path:
             print("No additional features as predictors? No problem, we'll stick to genotypes.")
-            self.addit_df = None
         else:
-            self.addit_df = pd.read_csv(addit_path, engine='c')
+            self.addit_df = pd.read_csv(addit_path, engine="c")
 
-        if (gwas_path==None):
+        if not gwas_path:
             print("So you don't want to filter on P values from external GWAS? No worries, we don't usually either (if the dataset is large enough).")
-            self.gwas_df = None
         else:
-            self.gwas_df = pd.read_csv(gwas_path, engine='c')
-            
-        if (geno_path==None):
-            print("So no genotypes? Okay, we'll just use additional features provided for the predictions.")
+            self.gwas_df = pd.read_csv(gwas_path, engine="c")
+
+        if not geno_path:
+            print(
+                "So no genotypes? Okay, we'll just use additional features provided for the predictions."
+            )
         else:
             print("Exporting genotype data")
 
+        self.output_datafile = self.run_prefix + ".dataForML.h5"
+        self.merged: Optional[pd.DataFrame] = None
+
     def plink_inputs(self):
         # Initializing some variables
-        plink_exec = genoml.dependencies.check_plink()
-        impute_type = self.impute_type
-        addit_df = self.addit_df
-        pheno_df = self.pheno_df
+        self.pheno_df.to_hdf(self.output_datafile, key="pheno", mode="w")
+        addit_df = None
 
-        outfile_h5 = self.run_prefix + ".dataForML.h5"
-        pheno_df.to_hdf(outfile_h5, key='pheno', mode='w')
+        genotype_df = self.load_genotypes()
 
-        if (self.geno_path != None):
-            if (self.skip_prune == "no"):
-            # Set the bashes
-                bash1a = f"{plink_exec} --bfile " + self.geno_path + " --indep-pairwise 1000 50 " + self.r2
-                bash1b = f"{plink_exec} --bfile " + self.geno_path + " --extract " + self.run_prefix + \
-                    ".p_threshold_variants.tab" + " --indep-pairwise 1000 50 " + self.r2
-            # may want to consider outputting temp_genos to dir in run_prefix
-                bash2 = f"{plink_exec} --bfile " + self.geno_path + \
-                    " --extract plink.prune.in --make-bed --out temp_genos"
-                bash3 = "cut -f 2,5 temp_genos.bim > " + \
-                    self.run_prefix + ".variants_and_alleles.tab"
-                bash4 = "rm plink.log"
-                bash5 = "rm plink.prune.*"
-            #    bash6 = "rm " + self.run_prefix + ".log"
-            # Set the bash command groups
-                cmds_a = [bash1a, bash2, bash3, bash4, bash5]
-                cmds_b = [bash1b, bash2, bash3, bash4, bash5]
-            
+        # Checking the imputation of non-genotype features
+        if self.addit_path:
+            addit_df = self.munge_additional_features()
 
-                if (self.gwas_path != None) & (self.geno_path != None):
-                    p_thresh = self.p_gwas
-                    gwas_df_reduced = self.gwas_df[['SNP', 'p']]
-                    snps_to_keep = gwas_df_reduced.loc[(
-                        gwas_df_reduced['p'] <= p_thresh)]
-                    outfile = self.run_prefix + ".p_threshold_variants.tab"
-                    snps_to_keep.to_csv(outfile, index=False, sep="\t")
-                    print(
-                        f"Your candidate variant list prior to pruning is right here: {outfile}.")
+        merged = _merge_dfs([self.pheno_df, genotype_df, addit_df], col_id="ID")
+        del addit_df, genotype_df  # We dont need these copies anymore
 
-                if (self.gwas_path == None) & (self.geno_path != None):
-                    print(
-                        f"A list of pruned variants and the allele being counted in the dosages (usually the minor allele) can be found here: {self.run_prefix}.variants_and_alleles.tab")
-                    for cmd in cmds_a:
-                        subprocess.run(cmd, shell=True)
+        merged = self.harmonize_refs(merged)
+        merged.to_hdf(self.output_datafile, key="dataForML")
 
-                if (self.gwas_path != None) & (self.geno_path != None):
-                    print(
-                        f"A list of pruned variants and the allele being counted in the dosages (usually the minor allele) can be found here: {self.run_prefix}.variants_and_alleles.tab")
-                    for cmd in cmds_b:
-                        subprocess.run(cmd, shell=True)
-        
-            if (self.skip_prune == "yes"):
-                bash1a = f"{plink_exec} --bfile " + self.geno_path 
-                bash1b = f"{plink_exec} --bfile " + self.geno_path + " --extract " + self.run_prefix + ".p_threshold_variants.tab" + " --make-bed --out temp_genos"
-            # may want to consider outputting temp_genos to dir in run_prefix
-                bash2 = f"{plink_exec} --bfile " + self.geno_path + " --make-bed --out temp_genos"
-                bash3 = "cut -f 2,5 temp_genos.bim > " + self.run_prefix + ".variants_and_alleles.tab"
-                bash4 = "rm plink.log"
+        features_list = merged.columns.tolist()
 
-            # Set the bash command groups
-                cmds_a = [bash1a, bash2, bash3, bash4]
-                cmds_b = [bash1b, bash3, bash4]
+        features_listpath = f"{self.run_prefix}.list_features.txt"
+        with open(features_listpath, "w") as f:
+            f.write("\n".join([str(feature) for feature in features_list]))
 
-                if (self.gwas_path != None) & (self.geno_path != None):
-                    p_thresh = self.p_gwas
-                    gwas_df_reduced = self.gwas_df[['SNP', 'p']]
-                    snps_to_keep = gwas_df_reduced.loc[(
-                        gwas_df_reduced['p'] <= p_thresh)]
-                    outfile = self.run_prefix + ".p_threshold_variants.tab"
-                    snps_to_keep.to_csv(outfile, index=False, sep="\t")
-                    print(
-                        f"Your candidate variant list is right here: {outfile}.")
-
-                if (self.gwas_path == None) & (self.geno_path != None):
-                    print(
-                        f"A list of variants and the allele being counted in the dosages (usually the minor allele) can be found here: {self.run_prefix}.variants_and_alleles.tab")
-                    for cmd in cmds_a:
-                        subprocess.run(cmd, shell=True)
-
-                if (self.gwas_path != None) & (self.geno_path != None):
-                    print(
-                        f"A list of variants and the allele being counted in the dosages (usually the minor allele) can be found here: {self.run_prefix}.variants_and_alleles.tab")
-                    for cmd in cmds_b:
-                        subprocess.run(cmd, shell=True)
-
-        if (self.geno_path != None):
-            
-            g = read_plink1_bin('temp_genos.bed')
-            g_pruned = g.drop(['fid','father','mother','gender', 'trait', 'chrom', 'cm', 'pos','a1'])
-
-            g_pruned = g_pruned.set_index({'sample':'iid','variant':'snp'})
-            g_pruned.values = g_pruned.values.astype('int')
-
-        # swap pandas-plink genotype coding to match .raw format...more about that below:
-
-        # for example, assuming C in minor allele, alleles are coded in plink .raw labels homozygous for minor allele as 2 and homozygous for major allele as 0:
-        #A A   ->    0   
-        #A C   ->    1   
-        #C C   ->    2
-        #0 0   ->   NA
-
-        # where as, read_plink1_bin flips these, with homozygous minor allele = 0 and homozygous major allele = 2
-        #A A   ->    2   
-        #A C   ->    1   
-        #C C   ->    0
-        #0 0   ->   NA
-
-            two_idx = (g_pruned.values == 2)
-            zero_idx = (g_pruned.values == 0)
-
-            g_pruned.values[two_idx] = 0
-            g_pruned.values[zero_idx] = 2
-
-            g_pd = g_pruned.to_pandas()
-            g_pd.reset_index(inplace=True)
-            raw_df = g_pd.rename(columns={'sample': 'ID'})
-        #    del raw_df.index.name
-        #    del raw_df.columns.name
-            
-        # now, remove temp_genos
-            bash_rm_temp = "rm temp_genos.*"
-            print(bash_rm_temp)
-            subprocess.run(bash_rm_temp, shell=True)
-
-    # Checking the impute flag and execute
-        # Currently only supports mean and median
-        impute_list = ["mean", "median"]
-        
-        if (self.geno_path != None):
-
-            if impute_type not in impute_list:
-                return "The 2 types of imputation currently supported are 'mean' and 'median'"
-            elif impute_type.lower() == "mean":
-                raw_df = raw_df.fillna(raw_df.mean())
-            elif impute_type.lower() == "median":
-                raw_df = raw_df.fillna(raw_df.median())
-            print("")
-            print(
-                f"You have just imputed your genotype features, covering up NAs with the column {impute_type} so that analyses don't crash due to missing data.")
-            print("Now your genotype features might look a little better (showing the first few lines of the left-most and right-most columns)...")
-            print("#"*70)
-            print(raw_df.describe())
-            print("#"*70)
-            print("")
-
-    # Checking the imputation of non-genotype features
-
-        if (self.addit_path != None):
-            if impute_type not in impute_list:
-                return "The 2 types of imputation currently supported are 'mean' and 'median'"
-            elif impute_type.lower() == "mean":
-                addit_df = addit_df.fillna(addit_df.mean())
-            elif impute_type.lower() == "median":
-                addit_df = addit_df.fillna(addit_df.median())
-            print("")
-            print(
-                f"You have just imputed your non-genotype features, covering up NAs with the column {impute_type} so that analyses don't crash due to missing data.")
-            print("Now your non-genotype features might look a little better (showing the first few lines of the left-most and right-most columns)...")
-            print("#"*70)
-            print(addit_df.describe())
-            print("#"*70)
-            print("")
-
-            # Remove the ID column
-            cols = list(addit_df.columns)
-            cols.remove('ID')
-            addit_df[cols]
-
-            # Z-scale the features
-            print(f"Now Z-scaling your non-genotype features...")
-
-            # Remove any columns with a standard deviation of zero
-            print(f"Removing any columns that have a standard deviation of 0 prior to Z-scaling...")
-            
-            if any(addit_df.std() == 0.0):
-                print("")
-                print(f"Looks like there's at least one column with a standard deviation of 0. Let's remove that for you...")
-                print("") 
-                addit_keep = addit_df.drop(addit_df.std()[addit_df.std() == 0.0].index.values, axis=1)
-                addit_keep_list = list(addit_keep.columns.values)
-                
-                addit_df = addit_df[addit_keep_list]
-                
-                addit_keep_list.remove('ID')
-                removed_list = np.setdiff1d(cols, addit_keep_list)
-                for removed_column in range(len(removed_list)):
-                    print(f"The column {removed_list[removed_column]} was removed")
-                    
-                cols = addit_keep_list
-            
-            print("")
-            for col in cols:
-                if (addit_df[col].min() == 0.0) and (addit_df[col].max() == 1.0):
-                    print(col, "is likely a binary indicator or a proportion and will not be scaled, just + 1 all the values of this variable and rerun to flag this column to be scaled.")
-                else:
-                    addit_df[col] = (addit_df[col] - addit_df[col].mean())/addit_df[col].std(ddof=0)
-            
-            print("")
-            print("You have just Z-scaled your non-genotype features, putting everything on a numeric scale similar to genotypes.")
-            print("Now your non-genotype features might look a little closer to zero (showing the first few lines of the left-most and right-most columns)...")
-            print("#"*70)
-            print(addit_df.describe())
-            print("#"*70)
-
-    # Saving out the proper HDF5 file
-        if (self.geno_path != None):
-            merged = raw_df.to_hdf(outfile_h5, key='geno')
-
-        if (self.addit_path != None):
-            merged = addit_df.to_hdf(outfile_h5, key='addit')
-
-        if (self.geno_path != None) & (self.addit_path != None):
-            pheno = pd.read_hdf(outfile_h5, key="pheno")
-            geno = pd.read_hdf(outfile_h5, key="geno")
-            addit = pd.read_hdf(outfile_h5, key="addit")
-            temp = pd.merge(pheno, addit, on='ID', how='inner')
-            merged = pd.merge(temp, geno, on='ID', how='inner')
-
-        if (self.geno_path != None) & (self.addit_path == None):
-            pheno = pd.read_hdf(outfile_h5, key="pheno")
-            geno = pd.read_hdf(outfile_h5, key="geno")
-            merged = pd.merge(pheno, geno, on='ID', how='inner')
-
-        if (self.geno_path == None) & (self.addit_path != None):
-            pheno = pd.read_hdf(outfile_h5, key="pheno")
-            addit = pd.read_hdf(outfile_h5, key="addit")
-            merged = pd.merge(pheno, addit, on='ID', how='inner')
-
-        # Checking the reference column names flag 
-        # If this is a step that comes after harmonize, then a .txt file with columns to keep should have been produced
-        # This is a list of column names from the reference dataset that the test dataset was harmonized against 
-        # We want to compare apples to apples, so we will only keep the column names that match
-        if (self.refColsHarmonize != None):
-            print("") 
-            print(f"Looks like you are munging after the harmonization step. Great! We will keep the columns generated from your reference dataset from that harmonize step that was exported to this file: {self.refColsHarmonize}")
-            print("")
-            with open(self.refColsHarmonize, 'r') as refCols_file:
-                ref_column_names_list = refCols_file.read().splitlines()
-            
-            # Keep the reference columns from the test dataset if found in test data
-            matching_cols = merged[np.intersect1d(merged.columns, ref_column_names_list)]
-            
-            # Make a list of final features that will be included in the model 
-                # This will be used again when remunging the reference dataset
-            matching_cols_list = matching_cols.columns.values.tolist()
-
-            # Save out the final list 
-            intersecting_cols_outfile = self.run_prefix + ".finalHarmonizedCols_toKeep.txt"
-
-            with open(intersecting_cols_outfile, 'w') as filehandle:
-                for col in matching_cols_list:
-                    filehandle.write('%s\n' % col)
-
-            print(f"A final list of harmonized columns between your reference and test dataset has been generated here: {intersecting_cols_outfile}")
-            print(f"Use this to re-train your reference dataset in order to move on to testing.")
-
-            # Replace the dataframe variable with the matching options
-            merged = matching_cols
+        print(
+            f"An updated list of {len(features_list)} features, including ID and PHENO,"
+            f" that is in your munged dataForML.h5 file can be found here "
+            f"{features_listpath}"
+            "\n"
+            f"Your .dataForML file that has been fully munged can be found here: "
+            f"{self.output_datafile}"
+        )
 
         self.merged = merged
-        merged.to_hdf(outfile_h5, key='dataForML')
+        return self.merged
 
-        features_list = merged.columns.values.tolist()
-    
-        features_listpath = self.run_prefix + ".list_features.txt"
-        with open(features_listpath, 'w') as f:
-            for feature in features_list:
-                f.write("%s\n" % feature)
+    def load_genotypes(self) -> Optional[pd.DataFrame]:
+        if not self.geno_path:
+            return None
 
-        print(f"An updated list of {len(features_list)} features, including ID and PHENO, that is in your munged dataForML.h5 file can be found here {features_listpath}")
+        self._run_external_plink_commands()
+        # read_plink1_bin reads in non-reference alleles. When `ref="a1"` (default),
+        # it counts "a0" alleles. We want to read homozygous minor allele as 2 and
+        # homozygous for major allele as 0. ref="a0" ensures we are counting the
+        # homozygous minor alleles. This matches the .raw labels.
+        g = read_plink1_bin("temp_genos.bed", ref="a0")
+        g = g.drop(
+            ["fid", "father", "mother", "gender", "trait", "chrom", "cm", "pos","a1"]
+        )
 
+        g = g.set_index({"sample": "iid", "variant": "snp"})
 
-        print("")
-        print(f"Your .dataForML file that has been fully munged can be found here: {outfile_h5}")
+        genotype_df = g.to_pandas()
+        del g  # We dont need this copy anymore
+        genotype_df.reset_index(inplace=True)
+        genotype_df.rename(columns={"sample": "ID"}, inplace=True)
 
-
+        # now, remove temp_genos
+        bash_rm_temp = "rm temp_genos.*"
+        print(bash_rm_temp)
+        subprocess.run(bash_rm_temp, shell=True)
+        # Checking the impute flag and execute
+        # Currently only supports mean and median
+        merged = _fill_impute_na(self.impute_type, genotype_df)
         return merged
+
+    def _run_external_plink_commands(self) -> None:
+        """Runs the external plink commands from the command line."""
+        if not self.geno_path:
+            return
+        cmds_a, cmds_b = get_plink_bash_scripts_options(
+            self.skip_prune, self.geno_path, self.run_prefix, self.r2
+        )
+        if self.gwas_path:
+            p_thresh = self.p_gwas
+            gwas_df_reduced = self.gwas_df[["SNP", "p"]]
+            snps_to_keep = gwas_df_reduced.loc[(gwas_df_reduced["p"] <= p_thresh)]
+            outfile = self.run_prefix + ".p_threshold_variants.tab"
+            snps_to_keep.to_csv(outfile, index=False, sep="\t")
+            prune_str = "" if self.skip_prune else "prior to pruning "
+            print(f"Your candidate variant list {prune_str}is right here: {outfile}.")
+            cmds = cmds_b
+        else:
+            cmds = cmds_a
+        pruned = "" if self.skip_prune else "pruned "
+        print(
+            f"A list of {pruned}variants and the allele being counted in the dosages "
+            "(usually the minor allele) can be found here: "
+            f"{self.run_prefix}.variants_and_alleles.tab"
+        )
+        for cmd in cmds:
+            subprocess.run(cmd, shell=True)
+
+    def munge_additional_features(self) -> Optional[pd.DataFrame]:
+        """Munges additional features and cleans up statistically insignificant data.
+
+        * Z-Scales the features.
+        * Remove any columns with a standard deviation of zero
+        """
+        if not self.addit_path:
+            return None
+        addit_df = _fill_impute_na(self.impute_type, self.addit_df)
+
+        # Remove the ID column
+        cols = [col for col in addit_df.columns if not col == "ID"]
+        addit_df.drop(labels="ID", axis=0, inplace=True)
+
+        # Remove any columns with a standard deviation of zero
+        print(
+            "Removing any columns that have a standard deviation of 0 prior to "
+            "Z-scaling..."
+        )
+        std = addit_df.std()
+        if any(std == 0.0):
+            print(
+                "\n"
+                "Looks like there's at least one column with a standard deviation "
+                "of 0. Let's remove that for you..."
+                "\n"
+            )
+            addit_keep = addit_df.drop(std[std == 0.0].index.values, axis=1)
+            addit_keep_list = list(addit_keep.columns.values)
+
+            addit_df = addit_df[addit_keep_list]
+
+            addit_keep_list.remove("ID")
+            removed_list = np.setdiff1d(cols, addit_keep_list)
+            for removed_column in range(len(removed_list)):
+                print(f"The column {removed_list[removed_column]} was removed")
+
+            cols = addit_keep_list
+
+        # Z-scale the features
+        print("Now Z-scaling your non-genotype features...\n")
+        for col in cols:
+            if (addit_df[col].min() == 0.0) and (addit_df[col].max() == 1.0):
+                print(
+                    f"{col} is likely a binary indicator or a proportion and will not "
+                    "be scaled, just + 1 all the values of this variable and rerun to "
+                    "flag this column to be scaled.",
+                )
+            else:
+                addit_df[col] = stats.zscore(addit_df[col], ddof=0)
+
+        print(
+            "\n"
+            "You have just Z-scaled your non-genotype features, putting everything on "
+            "a numeric scale similar to genotypes.\n"
+            "Now your non-genotype features might look a little closer to zero "
+            "(showing the first few lines of the left-most and right-most columns)..."
+        )
+        print("#" * 70)
+        print(addit_df.describe())
+        print("#" * 70)
+        return addit_df
+
+    def harmonize_refs(self, merged_df: pd.DataFrame) -> pd.DataFrame:
+        """Harmonizes data columns with an external reference file.
+
+        > Checking the reference column names flag
+        > If this is a step that comes after harmonize, then a .txt file with columns
+        > to keep should have been produced. This is a list of column names from the
+        > reference dataset that the test dataset was harmonized against. We want to
+        > compare apples to apples, so we will only keep the column names that match.
+        """
+        if not self.refColsHarmonize:
+            return merged_df
+        print(
+            "\n"
+            f"Looks like you are munging after the harmonization step. Great! We will "
+            f"keep the columns generated from your reference dataset from that "
+            f"harmonize step that was exported to this file: {self.refColsHarmonize}\n"
+        )
+        with open(self.refColsHarmonize, "r") as refCols_file:
+            ref_column_names_list = refCols_file.read().splitlines()
+
+        # Keep the reference columns from the test dataset if found in test data
+        matching_cols = merged_df[
+            np.intersect1d(merged_df.columns, ref_column_names_list)
+        ]
+
+        # Make a list of final features that will be included in the model
+        # This will be used again when remunging the reference dataset
+        matching_cols_list = matching_cols.columns.values.tolist()
+
+        # Save out the final list
+        intersecting_cols_outfile = f"{self.run_prefix}.finalHarmonizedCols_toKeep.txt"
+
+        with open(intersecting_cols_outfile, "w") as f:
+            for col in matching_cols_list:
+                f.write(f"{col}\n")
+
+        print(
+            "A final list of harmonized columns between your reference and test "
+            f"dataset has been generated here: {intersecting_cols_outfile}\n"
+            "Use this to re-train your reference dataset in order to move on to "
+            "testing."
+        )
+        return matching_cols
+
+
+def get_plink_bash_scripts_options(
+    skip_prune: bool, geno_path: str, run_prefix: str, r2: Optional[str] = None
+) -> Tuple[List, List]:
+    """Gets the PLINK bash scripts to be run from CLI."""
+    plink_exec = genoml.dependencies.check_plink()
+    if not skip_prune:
+        # Set the bashes
+        bash1a = f"{plink_exec} --bfile {geno_path} --indep-pairwise 1000 50 {r2}"
+        bash1b = (
+            f"{plink_exec} --bfile {geno_path} --extract "
+            f"{run_prefix}.p_threshold_variants.tab --indep-pairwise 1000 50 {r2}"
+        )
+        # may want to consider outputting temp_genos to dir in run_prefix
+        bash2 = (
+            f"{plink_exec} --bfile {geno_path} --extract plink.prune.in --make-bed"
+            f" --out temp_genos"
+        )
+        bash3 = f"cut -f 2,5 temp_genos.bim > {run_prefix}.variants_and_alleles.tab"
+        bash4 = "rm plink.log"
+        bash5 = "rm plink.prune.*"
+        #    bash6 = "rm " + self.run_prefix + ".log"
+        # Set the bash command groups
+        cmds_a = [bash1a, bash2, bash3, bash4, bash5]
+        cmds_b = [bash1b, bash2, bash3, bash4, bash5]
+    else:
+        bash1a = f"{plink_exec} --bfile {geno_path}"
+        bash1b = (
+            f"{plink_exec} --bfile {geno_path} --extract "
+            f"{run_prefix}.p_threshold_variants.tab --make-bed --out temp_genos"
+        )
+        # may want to consider outputting temp_genos to dir in run_prefix
+        bash2 = f"{plink_exec} --bfile {geno_path} --make-bed --out temp_genos"
+        bash3 = f"cut -f 2,5 temp_genos.bim > {run_prefix}.variants_and_alleles.tab"
+        bash4 = "rm plink.log"
+
+        # Set the bash command groups
+        cmds_a = [bash1a, bash2, bash3, bash4]
+        cmds_b = [bash1b, bash3, bash4]
+    return cmds_a, cmds_b
+
+
+def _fill_impute_na(impute_type: str, df: pd.DataFrame) -> pd.DataFrame:
+    """Imputes the NA fields for a dataframe."""
+    if impute_type.lower() == "mean":
+        df = df.fillna(df.mean())
+    elif impute_type.lower() == "median":
+        df = df.fillna(df.median())
+    print(
+        "\n"
+        "You have just imputed your genotype features, covering up NAs with "
+        f"the column {impute_type} so that analyses don't crash due to "
+        "missing data.\n"
+        "Now your genotype features might look a little better (showing the "
+        "first few lines of the left-most and right-most columns)..."
+    )
+    print("#" * 70)
+    print(df.describe())
+    print("#" * 70)
+    print("")
+    return df
+
+
+def _merge_dfs(dfs: List[pd.DataFrame], col_id: str) -> pd.DataFrame:
+    merged = None
+    for df in dfs:
+        if df is None:
+            continue
+        if merged is None:
+            merged = df
+        else:
+            merged = pd.merge(merged, df, on=col_id, how="inner")
+    return merged


### PR DESCRIPTION
Refactors the munging code for more programmatic access.

This refactoring should help with readability/tracing of the munging code by separating the cli/loading/modifying functionality. Black was run on this code for auto formatting (some lines left unformatted). Most of the block-print statements have been unified into a single print statement so readers and users will see a very similar output.

Downstream, the main difference with this change is the removal of the `addit_df`&`pheno_df`&`genotype_df` from the `dataForML.h5` file. This should reduce the overall data duplication and speed up munging times significantly. 