### PR TITLE
Updates to discrete output file and code structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ OR
 
 > Note: When you pip install this package, the examples/ folder is also downloaded! However, if  you still want to download the directory and SVN is not pre-installed, you can download it via Homebrew if you have that installed using `brew install svn` 
 
+### CHANGELOG
+- 8-OCT-2024: Big changes to output file structure, so now output files go in subdirectories named for each step, and prefixes are not required. `README` updated to reflect these changes.
+
+
 ### Table of Contents 
 #### [0. (OPTIONAL) How to Set Up a Virtual Environment via Conda](#0)
 #### [1. Munging with GenoML](#1)
@@ -124,7 +128,7 @@ If you would like to munge just with genotypes (in PLINK binary format), the sim
 # Running GenoML munging on discrete data using PLINK genotype binary files and a phenotype file 
 
 genoml discrete supervised munge \
---prefix outputs/test_discrete_geno \
+--prefix outputs \
 --geno examples/discrete/training \
 --pheno examples/discrete/training_pheno.csv
 ```
@@ -134,7 +138,7 @@ If you would like to control the pruning stringency in genotypes:
 # Running GenoML munging on discrete data using PLINK genotype binary files and a phenotype file 
 
 genoml discrete supervised munge \
---prefix outputs/test_discrete_geno \
+--prefix outputs \
 --geno examples/discrete/training \
 --r2_cutoff 0.3 \
 --pheno examples/discrete/training_pheno.csv
@@ -145,7 +149,7 @@ You can choose to skip pruning your SNPs at this stage by changing the `--skip_p
 # Running GenoML munging on discrete data using PLINK genotype binary files and a phenotype file 
 
 genoml discrete supervised munge \
---prefix outputs/test_discrete_geno \
+--prefix outputs \
 --geno examples/discrete/training \
 --skip_prune yes \
 --pheno examples/discrete/training_pheno.csv
@@ -156,7 +160,7 @@ You can choose to impute on `mean` or `median` by modifying the `--impute` flag,
 # Running GenoML munging on discrete data using PLINK genotype binary files and a phenotype file and specifying impute
 
 genoml discrete supervised munge \
---prefix outputs/test_discrete_geno \
+--prefix outputs \
 --geno examples/discrete/training \
 --pheno examples/discrete/training_pheno.csv \
 --impute mean
@@ -167,7 +171,7 @@ If you suspect collinear variables, and think this will be a problem for trainin
 # Running GenoML munging on discrete data using PLINK genotype binary files and a phenotype file while using VIF to remove multicollinearity 
 
 genoml discrete supervised munge \
---prefix outputs/test_discrete_geno \
+--prefix outputs \
 --geno examples/discrete/training \
 --pheno examples/discrete/training_pheno.csv \
 --vif 5 \
@@ -182,7 +186,7 @@ Well, what if you had GWAS summary statistics handy, and would like to just use 
 # Running GenoML munging on discrete data using PLINK genotype binary files, a phenotype file, and a GWAS summary statistics file 
 
 genoml discrete supervised munge \
---prefix outputs/test_discrete_geno \
+--prefix outputs \
 --geno examples/discrete/training \
 --pheno examples/discrete/training_pheno.csv \
 --gwas examples/discrete/example_GWAS.csv
@@ -194,7 +198,7 @@ genoml discrete supervised munge \
 # Running GenoML munging on discrete data using PLINK genotype binary files, a phenotype file, and a GWAS summary statistics file with a p-value cut-off 
 
 genoml discrete supervised munge \
---prefix outputs/test_discrete_geno \
+--prefix outputs \
 --geno examples/discrete/training \
 --pheno examples/discrete/training_pheno.csv \
 --gwas examples/discrete/example_GWAS.csv \
@@ -205,7 +209,7 @@ Do you have additional data you would like to incorporate? Perhaps clinical, dem
 # Running GenoML munging on discrete data using PLINK genotype binary files, a phenotype file, and an addit file
 
 genoml discrete supervised munge \
---prefix outputs/test_discrete_geno \
+--prefix outputs \
 --geno examples/discrete/training \
 --pheno examples/discrete/training_pheno.csv \
 --addit examples/discrete/training_addit.csv
@@ -215,7 +219,7 @@ You also have the option of not using PLINK binary files if you would like to ju
 # Running GenoML munging on discrete data using PLINK genotype binary files, a phenotype file, and an addit file
 
 genoml discrete supervised munge \
---prefix outputs/test_discrete_geno \
+--prefix outputs \
 --pheno examples/discrete/training_pheno.csv \
 --addit examples/discrete/training_addit.csv
 ```
@@ -225,7 +229,7 @@ Are you interested in selecting and ranking your features? If so, you can use th
 # Running GenoML munging on discrete data using PLINK genotype binary files, a phenotype file, and running feature selection 
 
 genoml discrete supervised munge \
---prefix outputs/test_discrete_geno \
+--prefix outputs \
 --geno examples/discrete/training \
 --pheno examples/discrete/training_pheno.csv \
 --addit examples/discrete/training_addit.csv \
@@ -244,7 +248,7 @@ To reduce your data prior to adjusting, use the `--umap_reduce yes` flag. This f
 # Running GenoML munging on discreate data using PLINK binary files, a phenotype file, using UMAP to reduce dimensions and account for features, and running feature selection
 
 genoml discrete supervised munge \
---prefix outputs/test_discrete_geno \
+--prefix outputs \
 --geno examples/discrete/training \
 --pheno examples/discrete/training_pheno.csv \
 --addit examples/discrete/training_addit.csv \
@@ -267,12 +271,12 @@ Training with GenoML competes a number of different algorithms and outputs the b
 - `mode`:  would you like to `munge`, `train`, `tune`, or `test` your model?
 - `--prefix` : Where would you like your outputs to be saved?
 
-The most basic command to train your model looks like the following, it looks for the `*.dataForML` file that was generated in the munging step: 
+The most basic command to train your model looks like the following, it looks for the `dataForML` file that was generated in the munging step: 
 ```shell
 # Running GenoML supervised training after munging on discrete data
 
 genoml discrete supervised train \
---prefix outputs/test_discrete_geno
+--prefix outputs
 ```
 
 If you would like to determine the best competing algorithm by something other than the AUC, you can do so by changing the `--metric_max` flag (Options include `AUC`, `Balanced_Accuracy`, `Sensitivity`, and `Specificity`) :
@@ -280,7 +284,7 @@ If you would like to determine the best competing algorithm by something other t
 # Running GenoML supervised training after munging on discrete data and specifying the metric to maximize by 
 
 genoml discrete supervised train \
---prefix outputs/test_discrete_geno \
+--prefix outputs \
 --metric_max Sensitivity
 ```
 > *Note:* The `--metric_max` flag is only available for discrete datasets.
@@ -293,7 +297,7 @@ The most basic command to tune your model looks like the following, it looks for
 # Running GenoML supervised tuning after munging and training on discrete data
 
 genoml discrete supervised tune \
---prefix outputs/test_discrete_geno
+--prefix outputs
 ```
 
 If you are interested in changing the number of iterations the tuning process goes through by modifying `--max_tune` *(default is 50)*, or the number of cross-validations by modifying `--n_cv` *(default is 5)*, this is what the command would look like: 
@@ -301,7 +305,7 @@ If you are interested in changing the number of iterations the tuning process go
 # Running GenoML supervised tuning after munging and training on discrete data, modifying the number of iterations and cross-validations 
 
 genoml discrete supervised tune \
---prefix outputs/test_discrete_geno \
+--prefix outputs \
 --max_tune 10 --n_cv 3
 ```
 
@@ -310,7 +314,7 @@ If you are interested in tuning on another metric other than AUC *(default is AU
 # Running GenoML supervised tuning after munging and training on discrete data, modifying the metric to tune by
 
 genoml discrete supervised tune \
---prefix outputs/test_discrete_geno \
+--prefix outputs \
 --metric_tune Balanced_Accuracy
 ```
 
@@ -337,8 +341,8 @@ Using GenoML for both your reference dataset and then your validation dataset, t
 
 **Required** arguments for harmonizing with GenoML are the following: 
 - `--test_geno_prefix` : What is the prefix of your validation dataset PLINK binaries?
-- `--test_prefix`: What do you want the output to be named?
-- `--ref_model_prefix`:  What is the name of the previously GenoML-munged dataset you would like to use as your reference dataset? (Without the `.dataForML.h5` suffix)
+- `--test_prefix`: What is the path to your output directory?
+- `--ref_model_prefix`:  What is the output directory containing the previously GenoML-munged dataset you would like to use as your reference dataset? (This is generated at `outputs/Munge`)
 - `--training_snps_alleles` : What are the SNPs and alleles you would like to use? (This is generated at the end of your previously-GenoML munged dataset with the suffix `variants_and_alleles.tab`)
 
 To harmonize your incoming validation dataset to match the SNPs and alleles to your reference dataset, the command would look like the following:
@@ -348,30 +352,32 @@ To harmonize your incoming validation dataset to match the SNPs and alleles to y
 
 genoml harmonize \
 --test_geno_prefix examples/discrete/validation \
---test_prefix outputs/validation_test_discrete_geno \
---ref_model_prefix outputs/test_discrete_geno \
---training_snps_alleles outputs/test_discrete_geno.variants_and_alleles.tab
+--test_prefix outputs \
+--ref_model_prefix outputs \
+--training_snps_alleles outputs/Munge/variants_and_alleles.tab
 ```
 
 This step will generate: 
-- a `*_refColsHarmonize_toKeep.txt` file of columns to keep for the next step 
-- `*_refSNPs_andAlleles.*` PLINK binary files (.bed, .bim, and .fam) that have the SNPs and alleles match your reference dataset
+- a `refColsHarmonize_toKeep.txt` file of columns to keep for the next step 
+- `refSNPs_andAlleles.*` PLINK binary files (.bed, .bim, and .fam) that have the SNPs and alleles match your reference dataset
+- Files are located at `outputs/Harmonize/`
 
 Now that you have harmonized your validation dataset to your reference dataset, you can now munge using a command similar to the following:
 ```shell
 # Running GenoML munge after GenoML harmonize
 
-genoml discrete supervised munge --prefix outputs/validation_test_discrete_geno \
---geno outputs/validation_test_discrete_geno_refSNPs_andAlleles \
+genoml discrete supervised munge 
+--prefix outputs \
+--geno outputs/Harmonize/refSNPs_andAlleles \
 --pheno examples/discrete/validation_pheno.csv \
 --addit examples/discrete/validation_addit.csv \
---ref_cols_harmonize outputs/validation_test_discrete_geno_refColsHarmonize_toKeep.txt
+--ref_cols_harmonize outputs/Harmonize/refColsHarmonize_toKeep.txt
 ```
-All munging options discussed above are available at this step, the only difference here is you will add the `--ref_cols_harmonize` flag to include the `*.refColsHarmonize_toKeep.txt` file generated at the end of harmonizing to only keep the same columns that the reference dataset had. 
+All munging options discussed above are available at this step, the only difference here is you will add the `--ref_cols_harmonize` flag to include the `refColsHarmonize_toKeep.txt` file generated at the end of harmonizing to only keep the same columns that the reference dataset had. 
 
 After munging and training your reference model and harmonizing and munging your unseen test data, **you will retrain your reference model to include only matching features**. Given the nature of ML algorithms, you cannot test a model on a set of data that does not have identical features. 
 
-To retrain your model appropriately, after munging your test data with the `--ref_cols_harmonize ` flag, a final columns list will be generated at `*.finalHarmonizedCols_toKeep.txt`. This includes all the features that match between your unseen test data and your reference model. Use the `--matching_columns` flag when retraining your reference model to use the appropriate features.
+To retrain your model appropriately, after munging your test data with the `--ref_cols_harmonize ` flag, a final columns list will be generated at `outputs/Munge/finalHarmonizedCols_toKeep.txt`. This includes all the features that match between your unseen test data and your reference model. Use the `--matching_columns` flag when retraining your reference model to use the appropriate features.
 
 When retraining of the reference model is complete, you are ready to test!
 
@@ -379,81 +385,81 @@ A step-by-step guide on how to achieve this is listed below:
 ```shell
 # 0. MUNGE THE REFERENCE DATASET
 genoml discrete supervised munge \
---prefix outputs/test_discrete_geno \
+--prefix outputs \
 --geno examples/discrete/training \
 --pheno examples/discrete/training_pheno.csv
 # Files made: 
-    # outputs/test_discrete_geno.dataForML.h5
-    # outputs/test_discrete_geno.list_features.txt
-    # outputs/test_discrete_geno.variants_and_alleles.tab
+    # outputs/Munge/dataForML.h5
+    # outputs/Munge/list_features.txt
+    # outputs/Munge/variants_and_alleles.tab
 
 # 1. TRAIN THE REFERENCE DATASET
 genoml discrete supervised train \
---prefix outputs/test_discrete_geno
+--prefix outputs
 # Files made: 
-    # outputs/test_discrete_geno.best_algorithm.txt
-    # outputs/test_discrete_geno.trainedModel.joblib
-    # outputs/test_discrete_geno.trainedModel_trainingSample_Predictions.csv
-    # outputs/test_discrete_geno.trainedModel_withheldSample_Predictions.csv
-    # outputs/test_discrete_geno.trainedModel_withheldSample_ROC.png
-    # outputs/test_discrete_geno.trainedModel_withheldSample_probabilities.png
-    # outputs/test_discrete_geno.training_withheldSamples_performanceMetrics.csv
+    # outputs/Train/best_algorithm.txt
+    # outputs/Train/trainedModel.joblib
+    # outputs/Train/trainedModel_trainingSample_Predictions.csv
+    # outputs/Train/trainedModel_withheldSample_Predictions.csv
+    # outputs/Train/trainedModel_withheldSample_ROC.png
+    # outputs/Train/trainedModel_withheldSample_probabilities.png
+    # outputs/Train/training_withheldSamples_performanceMetrics.csv
 
 # 2. HARMONIZE TEST DATASET IF USING PLINK/GENOTYPES
 genoml harmonize \
 --test_geno_prefix examples/discrete/validation \
---test_prefix outputs/validation_test_discrete_geno \
---ref_model_prefix outputs/test_discrete_geno \
---training_snps_alleles outputs/test_discrete_geno.variants_and_alleles.tab
+--test_prefix outputs \
+--ref_model_prefix outputs \
+--training_snps_alleles outputs/Harmonize/variants_and_alleles.tab
 # Files made: 
-    # outputs/validation_test_discrete_geno.refColsHarmonize_toKeep.txt
-    # outputs/validation_test_discrete_geno.refSNPs_andAlleles.bed
-    # outputs/validation_test_discrete_geno.refSNPs_andAlleles.bim
-    # outputs/validation_test_discrete_geno.refSNPs_andAlleles.fam
+    # outputs/Harmonize/refColsHarmonize_toKeep.txt
+    # outputs/Harmonize/refSNPs_andAlleles.bed
+    # outputs/Harmonize/refSNPs_andAlleles.bim
+    # outputs/Harmonize/refSNPs_andAlleles.fam
 
 # 3. MUNGE THE TEST DATASET ON REFERENCE MODEL COLUMNS
 genoml discrete supervised munge \
---prefix outputs/validation_test_discrete_geno \
---geno outputs/validation_test_discrete_geno.refSNPs_andAlleles \
+--prefix outputs \
+--geno outputs/Harmonize/refSNPs_andAlleles \
 --pheno examples/discrete/validation_pheno.csv \
 --addit examples/discrete/validation_addit.csv \
---ref_cols_harmonize outputs/validation_test_discrete_geno.refColsHarmonize_toKeep.txt
+--ref_cols_harmonize outputs/Harmonize/refColsHarmonize_toKeep.txt
 # Files made: 
-    # outputs/validation_test_discrete_geno.finalHarmonizedCols_toKeep.txt
-    # outputs/validation_test_discrete_geno.list_features.txt
-    # outputs/test_discrete_geno.variants_and_alleles.tab
-    # outputs/validation_test_discrete_geno.dataForML.h5
+    # outputs/Munge/finalHarmonizedCols_toKeep.txt
+    # outputs/Munge/list_features.txt
+    # outputs/Munge/variants_and_alleles.tab
+    # outputs/Munge/dataForML.h5
 
 # 4. RETRAIN REFERENCE MODEL ON INTERSECTING COLUMNS BETWEEN REFERENCE AND TEST
 genoml discrete supervised train \
---prefix outputs/test_discrete_geno \
---matching_columns outputs/validation_test_discrete_geno.finalHarmonizedCols_toKeep.txt
+--prefix outputs \
+--matching_columns outputs/Munge/finalHarmonizedCols_toKeep.txt
 # Note: This replaces the trained model you made in step 1! 
 # Files made: 
-    # outputs/test_discrete_geno.best_algorithm.txt
-    # outputs/test_discrete_geno.trainedModel.joblib
-    # outputs/test_discrete_geno.trainedModel_trainingSample_Predictions.csv
-    # outputs/test_discrete_geno.trainedModel_withheldSample_Predictions.csv
-    # outputs/test_discrete_geno.trainedModel_withheldSample_ROC.png
-    # outputs/test_discrete_geno.trainedModel_withheldSample_probabilities.png
-    # outputs/test_discrete_geno.training_withheldSamples_performanceMetrics.csv
+    # outputs/Train/best_algorithm.txt
+    # outputs/Train/trainedModel.joblib
+    # outputs/Train/trainedModel_trainingSample_Predictions.csv
+    # outputs/Train/trainedModel_withheldSample_Predictions.csv
+    # outputs/Train/trainedModel_withheldSample_ROC.png
+    # outputs/Train/trainedModel_withheldSample_probabilities.png
+    # outputs/Train/training_withheldSamples_performanceMetrics.csv
 
 # OPTIONAL: TUNING YOUR RETRAINED REFERENCE MODEL ON INTERSECTING COLUMNS BETWEEN REFERENCE AND TEST
 genoml discrete supervised tune \
 --prefix outputs/test_discrete_geno \
---matching_columns outputs/validation_test_discrete_geno.finalHarmonizedCols_toKeep.txt
+--matching_columns outputs/Munge/finalHarmonizedCols_toKeep.txt
 
 # 5. TEST RETRAINED REFERENCE MODEL OR TUNED MODEL ON UNSEEN DATA
 genoml discrete supervised test \
---prefix outputs/validation_test_discrete_geno \
---test_prefix outputs/validation_test_discrete_geno \
---ref_model_prefix outputs/test_discrete_geno.trainedModel
-    # If testing a tuned model, change suffix from .trainedModel to .tunedModel
+--prefix outputs \
+--test_prefix outputs \
+--ref_model_prefix outputs/Train/trainedModel
+    # If testing a tuned model, change path from `*/Train/trainedModel` to `*/Tune/tunedModel`
 # Files made: 
-    # outputs/validation_test_discrete_geno.testedModel_allSample_predictions.csv
-    # outputs/validation_test_discrete_geno.testedModel_allSample_probabilities.png
-    # outputs/validation_test_discrete_geno.testedModel_allSample_ROC.png
-    # outputs/validation_test_discrete_geno.testedModel_allSamples_performanceMetrics.csv
+    # outputs/Test/testedModel_allSample_predictions.csv
+    # outputs/Test/testedModel_allSample_probabilities.png
+    # outputs/Test/testedModel_allSample_ROC.png
+    # outputs/Test/testedModel_allSamples_performanceMetrics.csv
 ```
 
 > *Note:* When munging the test dataset on the reference model columns using the --ref_cols_harmonize, be sure not to include the --feature_selection flag, as you have already specified the columns to keep moving forward.

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ genoml discrete supervised train \
 
 # OPTIONAL: TUNING YOUR RETRAINED REFERENCE MODEL ON INTERSECTING COLUMNS BETWEEN REFERENCE AND TEST
 genoml discrete supervised tune \
---prefix outputs/test_discrete_geno \
+--prefix outputs \
 --matching_columns outputs/Munge/finalHarmonizedCols_toKeep.txt
 
 # 5. TEST RETRAINED REFERENCE MODEL OR TUNED MODEL ON UNSEEN DATA

--- a/genoml/cli/continuous_supervised_test.py
+++ b/genoml/cli/continuous_supervised_test.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 # ==============================================================================
 
-import sys
+from genoml.continuous import supervised
 import joblib
 import pandas as pd
-
-from genoml.continuous import supervised
+from pathlib import Path
+import sys
 
 
 def main(prefix, test_prefix, refModel_prefix):
@@ -30,23 +30,25 @@ def main(prefix, test_prefix, refModel_prefix):
     print("CLI argument info...")
     print(f"You are importing this test dataset: {test_prefix}.")
     print(f"You are applying the model saved here: {refModel_prefix}.")
-    print(
-        f"The results of this test application of your model will be saved in files with the given prefix: {prefix}.")
-    print(
-        "As a note, in all exported probabilities and other graphics, case status is treated as a 0 or 1, with 1 representing a positive case.")
+    print(f"The results of this test application of your model will be saved in files with the given prefix: {prefix}.")
+    print("As a note, in all exported probabilities and other graphics, case status is treated as a 0 or 1, with 1 "
+          "representing a positive case.")
 
     print("")
 
     # Specify prefix and dataframe variables to be passed into class
-    run_prefix = prefix
-    infile_h5 = test_prefix + ".dataForML.h5"
+    #run_prefix = prefix
+    #infile_h5 = test_prefix + ".dataForML.h5"
+    #df = pd.read_hdf(infile_h5, key="dataForML")
+    infile_h5 = Path(prefix).joinpath("Munge").joinpath("dataForML.h5")
     df = pd.read_hdf(infile_h5, key="dataForML")
 
-    infile_model = refModel_prefix + ".joblib"
+    infile_model = Path(prefix).joinpath("Tune").joinpath("tunedModel.joblib")
     loaded_model = joblib.load(infile_model)
 
     # Pass the arguments to the class 
-    test = supervised.test(df, loaded_model, run_prefix)
+    #test = supervised.test(df, loaded_model, run_prefix)
+    test = supervised.test(df, loaded_model, prefix)
 
     # Prep and show the dataframe
     test.prep_df()
@@ -62,6 +64,5 @@ def main(prefix, test_prefix, refModel_prefix):
 
     # Thank the user
     print("")
-    print(
-        "Let's shut everything down, thanks for testing your model with GenoML!")
+    print("Let's shut everything down, thanks for testing your model with GenoML!")
     print("")

--- a/genoml/cli/continuous_supervised_train.py
+++ b/genoml/cli/continuous_supervised_train.py
@@ -17,7 +17,7 @@ import sys
 
 import numpy as np
 import pandas as pd
-
+from pathlib import Path
 from genoml import utils
 from genoml.continuous import supervised
 
@@ -28,7 +28,7 @@ def main(run_prefix, export_predictions, matching_columns_path):
     utils.DescriptionLoader.print("cli/continuous_supervised_train/info",
                                   python_version=sys.version, prefix=run_prefix)
 
-    input_path = run_prefix + ".dataForML.h5"
+    input_path = Path(run_prefix).joinpath("Munge").joinpath("dataForML.h5")
     with utils.DescriptionLoader.context(
             "cli/continuous_supervised_train/input", path=input_path):
         df = pd.read_hdf(input_path, key="dataForML")

--- a/genoml/cli/continuous_supervised_tune.py
+++ b/genoml/cli/continuous_supervised_tune.py
@@ -14,39 +14,55 @@
 # ==============================================================================
 
 import pandas as pd
-
 from genoml.continuous import supervised
+from pathlib import Path
+import numpy as np
 
 
-def main(run_prefix, max_iter, cv_count):
+def main(run_prefix, max_iter, cv_count, matchingCols):
     # TUNING 
     # Create a dialogue with the user 
     print("Here is some basic info on the command you are about to run.")
     print("CLI argument info...")
-    print(f"Working with the dataset and best model corresponding to prefix {run_prefix} the timestamp from the merge is the prefix in most cases.")
-    print(f"Your maximum number of tuning iterations is {max_iter} and if you are concerned about runtime, make this number smaller.")
-    print(f"You are running {cv_count} rounds of cross-validation, and again... if you are concerned about runtime, make this number smaller.")
-    print("Give credit where credit is due, for this stage of analysis we use code from the great contributors to python packages: argparse, xgboost, sklearn, pandas, numpy, time, matplotlib and seaborn.")
-    print("As a note, in all exported probabilities and other graphics, case status is treated as a 0 or 1, with 1 representing a positive case.")
-
+    print(f"Working with the dataset and best model corresponding to prefix {run_prefix} the timestamp from the merge "
+          f"is the prefix in most cases.")
+    print(f"Your maximum number of tuning iterations is {max_iter} and if you are concerned about runtime, make this "
+          f"number smaller.")
+    print(f"You are running {cv_count} rounds of cross-validation, and again... if you are concerned about runtime, "
+          f"make this number smaller.")
+    print("Give credit where credit is due, for this stage of analysis we use code from the great contributors to "
+          "python packages: argparse, xgboost, sklearn, pandas, numpy, time, matplotlib and seaborn.")
+    print("As a note, in all exported probabilities and other graphics, case status is treated as a 0 or 1, with 1 "
+          "representing a positive case.")
     print("")
     
-    infile_h5 = run_prefix + ".dataForML.h5"
-    df = pd.read_hdf(infile_h5, key = "dataForML")
+    infile_h5 = Path(run_prefix).joinpath("Munge").joinpath("dataForML.h5")
+    df = pd.read_hdf(infile_h5, key="dataForML")
+
+    # Addressing issue #12:
+    if (matchingCols != None):
+        print(f"We are using the harmonized columns you provided here: {matchingCols}")
+        print(f"Note that you might have different/less features than before, given this was column list was harmonized between your reference and test dataset...")
+
+        with open(matchingCols, 'r') as matchingCols_file:
+            matching_column_names_list = matchingCols_file.read().splitlines()
+
+        # Keep only the columns found in the file
+        df = df[np.intersect1d(df.columns, matching_column_names_list)]
 
     y_tune = df.PHENO
     X_tune = df.drop(columns=['PHENO'])
     IDs_tune = X_tune.ID
     X_tune = X_tune.drop(columns=['ID'])
 
-
-    best_algo_name_in = run_prefix + '.best_algorithm.txt'
+    best_algo_name_in = Path(run_prefix).joinpath("Train").joinpath('best_algorithm.txt')
     best_algo_df = pd.read_csv(best_algo_name_in, header=None, index_col=False)
     best_algo = str(best_algo_df.iloc[0,0])
     
 
     # Communicate to the user the best identified algorithm 
-    print(f"From previous analyses in the training phase, we've determined that the best algorithm for this application is {best_algo}... so let's tune it up and see what gains we can make!")
+    print(f"From previous analyses in the training phase, we've determined that the best algorithm for this "
+          f"application is {best_algo}... so let's tune it up and see what gains we can make!")
 
     # Tuning 
     ## This calls on the functions made in the tune class (tuning.py) at the genoml.continuous.supervised

--- a/genoml/cli/discrete_supervised_test.py
+++ b/genoml/cli/discrete_supervised_test.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 # ==============================================================================
 
-import sys
+from genoml.discrete import supervised
 import joblib
 import pandas as pd
-
-from genoml.discrete import supervised
+from pathlib import Path
+import sys
 
 def main(prefix, test_prefix, refModel_prefix):
     print("")
@@ -35,30 +35,25 @@ def main(prefix, test_prefix, refModel_prefix):
     print("")
 
     # Specify prefix and dataframe variables to be passed into class
-    run_prefix = prefix
-    infile_h5 = test_prefix + ".dataForML.h5"
-    df = pd.read_hdf(infile_h5, key = "dataForML")
-
-    infile_model = refModel_prefix + ".joblib"
+    infile_h5 = Path(prefix).joinpath("Munge").joinpath("dataForML.h5")
+    infile_model = Path(prefix).joinpath("Tune").joinpath("tunedModel.joblib")
     loaded_model = joblib.load(infile_model)
 
-    # Pass the arguments to the class 
-    test = supervised.test(df, loaded_model, run_prefix)
+    # Pass the arguments to the class
+    df = pd.read_hdf(infile_h5, key="dataForML")
+    test = supervised.test(df, loaded_model, prefix)
 
     # Prep and show the dataframe
     test.prep_df()
 
-    # Export the ROC
-    test.export_ROC()
+    # Export the ROC and precision-recall plots
+    test.plot_results(save=True)
 
-    # Export the tested data 
-    test.export_tested_data()
-
-    # Export the histograms
-    test.export_histograms()
+    # Export the probability histograms and data tables.
+    test.export_prediction_data()
 
     # Export the additional summary stats
-    test.additional_sumstats()
+    #test.additional_sumstats()
 
     # Thank the user
     print("")

--- a/genoml/cli/discrete_supervised_train.py
+++ b/genoml/cli/discrete_supervised_train.py
@@ -16,7 +16,7 @@
 import sys
 import numpy as np
 import pandas as pd
-
+from pathlib import Path
 from genoml.discrete import supervised
 
 
@@ -36,7 +36,7 @@ def main(prefix, metric_max, prob_hist, auc, matchingCols):
 
     # Specify prefix and dataframe variables to be passed into class
     run_prefix = prefix
-    infile_h5 = run_prefix + ".dataForML.h5"
+    infile_h5 = Path(run_prefix).joinpath("Munge").joinpath("dataForML.h5")
     df = pd.read_hdf(infile_h5, key = "dataForML")
 
     if (matchingCols != None):
@@ -82,13 +82,13 @@ def main(prefix, metric_max, prob_hist, auc, matchingCols):
     # Export the results 
     model.export_model()
 
-    # Export the AUC     
-    model.AUC(save=True)
+    # Export the ROC and precision-recall plots
+    model.plot_results(save=True)
 
-    # Export the probability histograms
-    model.export_prob_hist()
+    # Export the probability histograms and data tables.
+    model.export_prediction_data()
 
     # Save out the proper algorithm
-    model.save_results(prefix, algorithmResults = True, bestAlgorithm = True)
+    model.save_results(algorithm_results=True, best_algorithm=True)
 
     print("Thank you for training with GenoML!")

--- a/genoml/cli/discrete_supervised_tune.py
+++ b/genoml/cli/discrete_supervised_tune.py
@@ -15,7 +15,7 @@
 
 import pandas as pd
 import numpy as np
-
+from pathlib import Path
 from genoml.discrete import supervised
 
 
@@ -33,7 +33,7 @@ def main(run_prefix, metric_tune, max_iter, cv_count, matchingCols):
 
     print("")
 
-    infile_h5 = run_prefix + ".dataForML.h5"
+    infile_h5 = Path(run_prefix).joinpath("Munge").joinpath("dataForML.h5")
     df = pd.read_hdf(infile_h5, key = "dataForML")
 
     # Addressing issue #12: 
@@ -47,7 +47,7 @@ def main(run_prefix, metric_tune, max_iter, cv_count, matchingCols):
         # Keep only the columns found in the file 
         df = df[np.intersect1d(df.columns, matching_column_names_list)]
 
-    best_algo_name_in = run_prefix + '.best_algorithm.txt'
+    best_algo_name_in = Path(run_prefix).joinpath("Train").joinpath('best_algorithm.txt')#run_prefix + 'best_algorithm.txt'
     best_algo_df = pd.read_csv(best_algo_name_in, header=None, index_col=False)
     best_algo = str(best_algo_df.iloc[0,0])
 
@@ -55,33 +55,14 @@ def main(run_prefix, metric_tune, max_iter, cv_count, matchingCols):
     print(f"From previous analyses in the training phase, we've determined that the best algorithm for this application is {best_algo}... so let's tune it up and see what gains we can make!")
 
     # Tuning 
-    ## This calls on the functions made in the tune class (tuning.py) at the genoml.discrete.supervised 
     model_tune = supervised.tune(df, run_prefix, max_iter, cv_count)
-    
-    # Returns algo, hyperparameters, and scoring_metric
-    model_tune.select_tuning_parameters(metric_tune) 
-    
-    # Randomized search with CV to tune
-    model_tune.apply_tuning_parameters() 
-    
-    # Summary of the top 10 iterations of the hyperparameter tune
+    model_tune.select_tuning_parameters(metric_tune)
+    model_tune.apply_tuning_parameters()
     model_tune.report_tune()
-
-    # Summary of the cross-validation 
     model_tune.summarize_tune()
-
-    # Compares tuned performance to baseline to 
     model_tune.compare_performance()
-
-    # Export the ROC curve 
-    # model_tune.ROC()
-
-    # Export the newly tuned predictions 
-    model_tune.export_tuned_data()
-
-    # Export the probabilites 
-    model_tune.export_tune_hist_prob() 
-
+    model_tune.plot_results(save=True)
+    model_tune.export_prediction_data()
 
     print("")
     print("End of tuning stage with GenoML.")

--- a/genoml/continuous/supervised/testing.py
+++ b/genoml/continuous/supervised/testing.py
@@ -13,23 +13,20 @@
 # limitations under the License.
 # ==============================================================================
 
-# Import the necessary packages 
-import joblib
-import matplotlib.pyplot as plt
+# Import the necessary packages
 import pandas as pd
+from pathlib import Path
 import seaborn as sns
-import sklearn
-import sys
-import xgboost
-import numpy as np
-from time import time
 import statsmodels.formula.api as sm
 from sklearn.metrics import explained_variance_score, mean_squared_error, median_absolute_error, r2_score
 
 class test:
     def __init__(self, df, loaded_model, run_prefix):
         self.df = df 
-        self.run_prefix = run_prefix
+        path = Path(run_prefix).joinpath("Test")
+        if not path.is_dir():
+            path.mkdir()
+        self.run_prefix = path
         self.loaded_model = loaded_model
 
     def prep_df(self):
@@ -85,13 +82,13 @@ class test:
         print("R^2 score: {:.4}".format(r2s))
             
         log_entry = pd.DataFrame([[evs, mse, mae, r2s]], columns=log_cols)
-        log_table = log_table.append(log_entry)
+        log_table = log_table._append(log_entry)
 
         print("#"*70)
 
         print("")
 
-        log_outfile = self.run_prefix + '.testedModel_allSamples_performanceMetrics.csv'
+        log_outfile = self.run_prefix.joinpath('testedModel_allSamples_performanceMetrics.csv')
 
         print("")
         print(f"This table below is also logged as {log_outfile} and is in your current working directory...")
@@ -116,7 +113,7 @@ class test:
         test_out.columns=["INDEX","ID","PHENO_REPORTED","PHENO_PREDICTED"]
         test_out = test_out.drop(columns=["INDEX"])
 
-        test_outfile = self.run_prefix + '.testedModel_allSample_predictions.csv'
+        test_outfile = self.run_prefix.joinpath('testedModel_allSample_predictions.csv')
         test_out.to_csv(test_outfile, index=False)
 
         print("")
@@ -135,7 +132,7 @@ class test:
 
         sns_plot = sns.regplot(data=self.test_out, y="PHENO_REPORTED", x="PHENO_PREDICTED", scatter_kws={"color": "cyan"}, line_kws={"color": "purple"})
 
-        plot_out = self.run_prefix + '.testedModel_allSamples_regressionPlot.png'
+        plot_out = self.run_prefix.joinpath('testedModel_allSamples_regressionPlot.png')
         sns_plot.figure.savefig(plot_out, dpi=600)
 
         print("")
@@ -149,7 +146,7 @@ class test:
         fitted = reg_model.fit()
         print(fitted.summary())
 
-        fitted_out = self.run_prefix + 'testedModel_allSamples_regressionSummary.csv'
+        fitted_out = self.run_prefix.joinpath('testedModel_allSamples_regressionSummary.csv')
         
         with open(fitted_out, 'w') as fh:
             fh.write(fitted.summary().as_csv())

--- a/genoml/continuous/supervised/tuning.py
+++ b/genoml/continuous/supervised/tuning.py
@@ -17,6 +17,7 @@ from joblib import dump
 from time import time
 import numpy as np
 import pandas as pd
+from pathlib import Path
 import seaborn as sns
 import sklearn
 from scipy import stats
@@ -36,7 +37,11 @@ import xgboost
 # Define the tune class 
 class tune():
     def __init__(self, df, run_prefix, max_iter, cv_count):
-        self.run_prefix = run_prefix
+        path = Path(run_prefix).joinpath("Tune")
+        if not path.is_dir():
+            path.mkdir()
+
+        self.run_prefix = path
         self.max_iter = max_iter
         self.cv_count = cv_count
        
@@ -45,7 +50,7 @@ class tune():
         self.IDs_tune = self.X_tune.ID
         self.X_tune = self.X_tune.drop(columns=['ID'])
 
-        best_algo_name_in = run_prefix + '.best_algorithm.txt'
+        best_algo_name_in = Path(run_prefix).joinpath("Train").joinpath('best_algorithm.txt')
         best_algo_df = pd.read_csv(best_algo_name_in, header=None, index_col=False)
         self.best_algo = str(best_algo_df.iloc[0,0])
 
@@ -82,7 +87,7 @@ class tune():
         if best_algo == 'LinearRegression':
             algo = getattr(sklearn.linear_model, best_algo)()
 
-        elif  best_algo == 'SGDRegressor':
+        elif best_algo == 'SGDRegressor':
             algo = getattr(sklearn.linear_model, best_algo)()
 
         elif (best_algo == 'RandomForestRegressor') or (best_algo == 'AdaBoostRegressor') or (best_algo == 'GradientBoostingRegressor') or  (best_algo == 'BaggingRegressor'):
@@ -99,14 +104,12 @@ class tune():
 
         elif best_algo == 'KNeighborsRegressor':
             algo = getattr(sklearn.neighbors, best_algo)()
-        
-        self.algo = algo 
 
         if best_algo == 'LinearRegression':
             hyperparameters = {"penalty": ["l1", "l2"], "C": stats.randint(1, 10)}
             scoring_metric = metrics.make_scorer(metrics.explained_variance_score)
 
-        elif  best_algo == 'SGDRegressor':
+        elif best_algo == 'SGDRegressor':
             hyperparameters = {'alpha': [1e-4, 1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3], "learning_rate": ["constant", "optimal", "invscaling", "adaptive"]}
             scoring_metric = metrics.make_scorer(metrics.explained_variance_score)
 
@@ -130,6 +133,7 @@ class tune():
             hyperparameters = {"leaf_size": stats.randint(1, 100), "n_neighbors": stats.randint(1, 10)}
             scoring_metric = metrics.make_scorer(metrics.explained_variance_score)
 
+        self.algo = algo
         self.hyperparameters = hyperparameters
         self.scoring_metric = scoring_metric
 
@@ -138,7 +142,16 @@ class tune():
     def apply_tuning_parameters(self):
         # Randomized search with CV to tune 
         print("Here is a summary of the top 10 iterations of the hyperparameter tuning...")
-        rand_search = model_selection.RandomizedSearchCV(estimator=self.algo, param_distributions=self.hyperparameters, scoring=self.scoring_metric, n_iter=self.max_iter, cv=self.cv_count, n_jobs=-1, random_state=153, verbose=0)
+        rand_search = model_selection.RandomizedSearchCV(
+            estimator=self.algo,
+            param_distributions=self.hyperparameters,
+            scoring=self.scoring_metric,
+            n_iter=self.max_iter,
+            cv=self.cv_count,
+            n_jobs=-1,
+            random_state=153,
+            verbose=0,
+        )
 
         start = time()
         rand_search.fit(self.X_tune, self.y_tune)
@@ -169,19 +182,21 @@ class tune():
                 print("Parameters: {0}".format(results['params'][candidate]))
                 print("")
                 top10_log_entry = pd.DataFrame([[i, results['mean_test_score'][candidate], results['std_test_score'][candidate], results['params'][candidate]]], columns=top10_log_cols)
-                top10_log_table = top10_log_table.append(top10_log_entry)
+                top10_log_table = top10_log_table._append(top10_log_entry)
         
-        log_outfile = self.run_prefix + '.tunedModel_top10Iterations_Summary.csv'
+        log_outfile = self.run_prefix.joinpath('tunedModel_top10Iterations_Summary.csv')
         top10_log_table.to_csv(log_outfile, index=False)
 
-        print(f"We are exporting a summary table of the top 10 iterations of the hyperparameter tuning step and its parameters here {log_outfile}.")
+        print(f"We are exporting a summary table of the top 10 iterations of the hyperparameter tuning step and its "
+              f"parameters here {log_outfile}.")
 
         return top10_log_table
 
     def summarize_tune(self):
         print("Here is the cross-validation summary of your best tuned model hyperparameters...")
         cv_tuned = model_selection.cross_val_score(estimator=self.rand_search.best_estimator_, X=self.X_tune, y=self.y_tune, scoring=self.scoring_metric, cv=self.cv_count, n_jobs=-1, verbose=0)
-        print("Scores per cross-validation of the metric to be maximized, this scoring metric is AUC or Balanced_Accuracy for discrete phenotypes and explained variance for continuous phenotypes:")
+        print("Scores per cross-validation of the metric to be maximized, this scoring metric is AUC or "
+              "Balanced_Accuracy for discrete phenotypes and explained variance for continuous phenotypes:")
         print(cv_tuned)
         print("Mean cross-validation score:")
         print(cv_tuned.mean())
@@ -190,9 +205,11 @@ class tune():
 
         print("")
 
-        print("Here is the cross-validation summary of your baseline/default hyperparamters for the same algorithm on the same data...")
+        print("Here is the cross-validation summary of your baseline/default hyperparamters for the same algorithm on "
+              "the same data...")
         cv_baseline = model_selection.cross_val_score(estimator=self.algo, X=self.X_tune, y=self.y_tune, scoring=self.scoring_metric, cv=self.cv_count, n_jobs=-1, verbose=0)
-        print("Scores per cross-validation of the metric to be maximized, this scoring metric is AUC or Balanced_Accuracy for discrete phenotypes and explained variance for continuous phenotypes:")
+        print("Scores per cross-validation of the metric to be maximized, this scoring metric is AUC or "
+              "Balanced_Accuracy for discrete phenotypes and explained variance for continuous phenotypes:")
         print(cv_baseline)
         print("")
         print("Mean Cross-Validation Score:")
@@ -202,7 +219,8 @@ class tune():
         print(cv_baseline.std())
 
         print("")
-        print("Just a note, if you have a relatively small variance among the cross-validation iterations, there is a higher chance of your model being more generalizable to similar datasets.")
+        print("Just a note, if you have a relatively small variance among the cross-validation iterations, there is a "
+              "higher chance of your model being more generalizable to similar datasets.")
 
         self.cv_baseline = cv_baseline
         self.cv_tuned = cv_tuned
@@ -211,11 +229,12 @@ class tune():
         summary_CV_log_cols = ["Mean_CV_Score_Baseline", "Standard_Dev_CV_Score_Baseline", "Min_CV_Score_Baseline", "Max_CV_Score_Baseline", "Mean_CV_Score_BestTuned", "Standard_Dev_CV_Score_BestTuned", "Min_CV_Score_BestTuned", "Max_CV_Score_BestTuned"]
         summary_CV_log_table = pd.DataFrame(columns=summary_CV_log_cols)
         summary_CV_log_entry = pd.DataFrame([[cv_baseline.mean(), cv_baseline.std(), cv_baseline.min(), cv_baseline.max(), cv_tuned.mean(), cv_tuned.std(), cv_tuned.min(), cv_tuned.max()]], columns=summary_CV_log_cols)
-        summary_CV_log_table = summary_CV_log_table.append(summary_CV_log_entry)
-        log_outfile = self.run_prefix + '.tunedModel_CV_Summary.csv'
+        summary_CV_log_table = summary_CV_log_table._append(summary_CV_log_entry)
+        log_outfile = self.run_prefix.joinpath('tunedModel_CV_Summary.csv')
         summary_CV_log_table.to_csv(log_outfile, index=False)
         
-        print(f"We are exporting a summary table of the cross-validation mean score and standard deviation of the baseline vs. best tuned model here {log_outfile}.")
+        print(f"We are exporting a summary table of the cross-validation mean score and standard deviation of the "
+              f"baseline vs. best tuned model here {log_outfile}.")
 
         return summary_CV_log_table
     
@@ -224,21 +243,26 @@ class tune():
         cv_baseline = self.cv_baseline
 
         if cv_baseline.mean() > cv_tuned.mean():
-            print("Based on comparisons of the default parameters to your hyperparameter tuned model, the baseline model actually performed better.")
-            print("Looks like the tune wasn't worth it, we suggest either extending the tune time or just using the baseline model for maximum performance.")
+            print("Based on comparisons of the default parameters to your hyperparameter tuned model, the baseline "
+                  "model actually performed better.")
+            print("Looks like the tune wasn't worth it, we suggest either extending the tune time or just using the "
+                  "baseline model for maximum performance.")
             print("")
             print("Let's shut everything down, thanks for trying to tune your model with GenoML.")
             return self.algo
 
         if cv_baseline.mean() < cv_tuned.mean():
-            print("Based on comparisons of the default parameters to your hyperparameter tuned model, the tuned model actually performed better.")
-            print("Looks like the tune was worth it, we suggest using this model for maximum performance, lets summarize and export this now.")
-            print("In most cases, if opting to use the tuned model, a separate test dataset is a good idea. GenoML has a module to fit models to external data.")
+            print("Based on comparisons of the default parameters to your hyperparameter tuned model, the tuned model "
+                  "actually performed better.")
+            print("Looks like the tune was worth it, we suggest using this model for maximum performance, lets "
+                  "summarize and export this now.")
+            print("In most cases, if opting to use the tuned model, a separate test dataset is a good idea. GenoML has "
+                  "a module to fit models to external data.")
 
             algo_tuned = self.rand_search.best_estimator_
                 
             ### Save it using joblib
-            algo_tuned_out = self.run_prefix + '.tunedModel.joblib'
+            algo_tuned_out = self.run_prefix.joinpath('tunedModel.joblib')
             dump(algo_tuned, algo_tuned_out)
 
             return algo_tuned
@@ -255,11 +279,12 @@ class tune():
 
         self.tune_out = tune_out
 
-        tune_outfile = self.run_prefix + '.tunedModel_allSample_Predictions.csv'
+        tune_outfile = self.run_prefix.joinpath('tunedModel_allSample_Predictions.csv')
         tune_out.to_csv(tune_outfile, index=False)
 
         print("")
-        print(f"Preview of the exported predictions for the tuning samples which is naturally overfit and exported as {tune_outfile} in the similar format as in the initial training phase of GenoML.")
+        print(f"Preview of the exported predictions for the tuning samples which is naturally overfit and exported as "
+              f"{tune_outfile} in the similar format as in the initial training phase of GenoML.")
         print("#"*70)
         print(tune_out.head())
         print("#"*70)
@@ -267,16 +292,23 @@ class tune():
     def export_tune_regression(self):
         genoML_colors = ["cyan","purple"]
         
-        sns_plot = sns.regplot(data=self.tune_out, y="PHENO_REPORTED", x="PHENO_PREDICTED", scatter_kws={"color": "cyan"}, line_kws={"color": "purple"})
+        sns_plot = sns.regplot(
+            data=self.tune_out,
+            y="PHENO_REPORTED",
+            x="PHENO_PREDICTED",
+            scatter_kws={"color": "cyan"},
+            line_kws={"color": "purple"},
+        )
         
-        plot_out = self.run_prefix + '.tunedModel_allSample_regression.png'
+        plot_out = self.run_prefix.joinpath('tunedModel_allSample_regression.png')
         sns_plot.figure.savefig(plot_out, dpi=600)
 
         print("")
-        print(f"We are also exporting a regression plot for you here {plot_out} this is a graphical representation of the difference between the reported and predicted phenotypes in all data for the tuned algorithm.")	
-
+        print(f"We are also exporting a regression plot for you here {plot_out} this is a graphical representation of "
+              f"the difference between the reported and predicted phenotypes in all data for the tuned algorithm.")
         print("")
-        print("Here is a quick summary of the regression comparing PHENO_REPORTED ~ PHENO_PREDICTED in the tuned data for all samples...")
+        print("Here is a quick summary of the regression comparing PHENO_REPORTED ~ PHENO_PREDICTED in the tuned data "
+              "for all samples...")
         print("")
 
         reg_model = sm.ols(formula='PHENO_REPORTED ~ PHENO_PREDICTED', data=self.tune_out)

--- a/genoml/discrete/supervised/testing.py
+++ b/genoml/discrete/supervised/testing.py
@@ -13,24 +13,18 @@
 # limitations under the License.
 # ==============================================================================
 
-# Import the necessary packages 
-import joblib
-import matplotlib.pyplot as plt
-import pandas as pd
-import seaborn as sns
-import sklearn
-import sys
-import xgboost
-import numpy as np
-from numpy import argmax
-from time import time
-from sklearn.metrics import accuracy_score, balanced_accuracy_score, log_loss, roc_auc_score, confusion_matrix, roc_curve, auc
+# Import the necessary packages
+from pathlib import Path
+import genoml.discrete.utils as discrete_utils
 
 class test:
     def __init__(self, df, loaded_model, run_prefix):
-        self.df = df # Generated from the harmonized test_prefix .h5 file 
-        self.run_prefix = run_prefix
-        self.loaded_model = loaded_model
+        self.df = df
+        path = Path(run_prefix).joinpath("Test")
+        if not path.is_dir():
+            path.mkdir()
+        self.run_prefix = path
+        self.algo = loaded_model
     
     def prep_df(self):
         print("")
@@ -51,140 +45,48 @@ class test:
         self.X_test = X_test
         self.IDs_test = IDs_test
 
-        return X_test
-    
-    def export_ROC(self):
-        
-        # Define the output prefix  
-        plot_out = self.run_prefix + '.testedModel_validationCohort_allCasesControls_ROC.png'
+    def plot_results(self, save=False):
+        # Issue #24: RandomForestClassifier is finicky - can't recalculate moving forward like the other
+        self.algo.fit(self.X_test, self.y_test)
+        plot_path = self.run_prefix.joinpath('testModel_withheldSample_ROC.png')
+        ground_truth = self.y_test.values
+        predictions = self.algo.predict(self.X_test)
+        discrete_utils.ROC(save, plot_path, ground_truth, predictions)
+        discrete_utils.precision_recall_plot(save, plot_path, ground_truth, predictions)
 
-        # Test the loaded model on validation cohort 
-        test_predictions = self.loaded_model.predict_proba(self.X_test)
-        self.test_predictions = test_predictions
-        test_predictions = test_predictions[:, 1]
+    def export_prediction_data(self):
+        test_out = discrete_utils.export_prediction_tables(
+            self.algo,
+            self.y_test,
+            self.X_test,
+            self.IDs_test,
+            self.run_prefix.joinpath('tunedModel_withheldSample_testingPredictions.csv'),
+        )
 
-        fpr, tpr, thresholds = roc_curve(self.y_test, test_predictions)
-        roc_auc = roc_auc_score(self.y_test, test_predictions)
-
-
-        plt.figure()
-        plt.plot(fpr, tpr, color='purple', label='ROC curve (area = %0.2f)' % roc_auc)
-        plt.plot([0, 1], [0, 1], color='cyan', linestyle='--', label='Chance (area = %0.2f)' % 0.5)
-        plt.xlim([0.0, 1.0])
-        plt.ylim([0.0, 1.05])
-        plt.xlabel('False Positive Rate')
-        plt.ylabel('True Positive Rate')
-        plt.title('Receiver Operating Characteristic (ROC) - Test Dataset' )
-        plt.legend(loc="lower right")
-        plt.savefig(plot_out, dpi = 600)
-
-        print("")
-        print(f"We are also exporting a ROC curve for you here {plot_out} this is a graphical representation of AUC in all samples for the best performing algorithm.")
-
-        self.roc_auc = roc_auc
-
-        return roc_auc
-            
-
-    def export_tested_data(self):
-        test_predicteds_probs = self.loaded_model.predict_proba(self.X_test)
-        test_case_probs = test_predicteds_probs[:, 1]
-        test_predicted_cases = self.loaded_model.predict(self.X_test)
-        self.test_predicteds_probs = test_predicteds_probs
-        self.test_predicted_cases = test_predicted_cases
-
-        test_case_probs_df = pd.DataFrame(test_case_probs)
-        test_predicted_cases_df = pd.DataFrame(test_predicted_cases)
-        y_test_df = pd.DataFrame(self.y_test)
-        IDs_test_df = pd.DataFrame(self.IDs_test)
-
-        test_out = pd.concat([IDs_test_df.reset_index(), y_test_df.reset_index(drop=True), test_case_probs_df.reset_index(drop=True), test_predicted_cases_df.reset_index(drop=True)], axis = 1, ignore_index=True)
-        test_out.columns=['INDEX','ID',"CASE_REPORTED","CASE_PROBABILITY","CASE_PREDICTED"]
-        test_out = test_out.drop(columns=['INDEX'])
-
-        test_outfile = self.run_prefix + '.testedModel_validationCohort_allCasesControls_predictions.csv'
-        test_out.to_csv(test_outfile, index=False)
-
-        print("")
-        print(f"Preview of the exported predictions for the testing samples exported as {test_outfile} in the similar format as in the initial training phase of GenoML.")
-        print("#"*70)
-        print(test_out.head())
-        print("#"*70)
-
-        self.test_out = test_out 
-
-        return test_out
-    
-    def export_histograms(self):
-        # Colors
-        genoML_colors = ["cyan","purple"]
-
-        to_plot_df = self.test_out
-        to_plot_df['percent_probability'] = to_plot_df['CASE_PROBABILITY']*100
-        to_plot_df['Probability (%)'] = to_plot_df['percent_probability'].round(decimals=0)
-        to_plot_df['Reported Status'] = to_plot_df['CASE_REPORTED']
-        to_plot_df['Predicted Status'] = to_plot_df['CASE_PREDICTED']
-
-        # Start plotting
-        sns.displot(data=to_plot_df, x="Probability (%)", hue="Predicted Status", col="Reported Status", kde=True, palette=genoML_colors, alpha=0.2)
-
-        plot_out = self.run_prefix + '.testedModel_validationCohort_allCasesControls_probabilities.png'
-        plt.savefig(plot_out, dpi=300)
-
-        print("")
-        print(f"We are also exporting probability density plots to the file {plot_out} this is a plot of the probability distributions of being a case, stratified by case and control status for all samples.")
-        print("")
+        discrete_utils.export_prob_hist(
+            test_out,
+            self.run_prefix.joinpath('tunedModel_withheldSample_testingProbabilities'),
+        )
 
     def additional_sumstats(self):
-        self.loaded_model.fit(self.X_test, self.y_test)
-
         print("")
         print("#"*70)
         print("Some additional summary stats logging from your application of your model to the test dataset.")
         print("")
 
-        print("AUC: {:.4%}".format(self.roc_auc)) # Pull the ROC from above, the same one in the plot
+        log_outfile = self.run_prefix.joinpath('tunedModel_validationCohort_allCasesControls_performanceMetrics.csv')
+        log_table = discrete_utils.summary_stats(
+            self.algo,
+            self.y_test,
+            self.X_test,
+        )
+        log_table.to_csv(log_outfile, index=False)
 
-        acc = accuracy_score(self.y_test, self.test_predicted_cases)
-        print("Accuracy: {:.4%}".format(acc))
-
-        balacc = balanced_accuracy_score(self.y_test, self.test_predicted_cases)
-        print("Balanced Accuracy: {:.4%}".format(balacc))
-            
-        CM = confusion_matrix(self.y_test, self.test_predicted_cases)
-        TN = CM[0][0]
-        FN = CM[1][0]
-        TP = CM[1][1]
-        FP = CM[0][1]
-        sensitivity = TP/(TP+FN)
-        specificity = TN/(TN+FP)
-        PPV = TP/(TP+FP)
-        NPV = TN/(TN+FN)
-        
-        ll = log_loss(self.y_test, self.test_predicteds_probs)
-        print("Log Loss: {:.4}".format(ll))
-
-        log_cols=["AUC_Percent", "Accuracy_Percent", "Balanced_Accuracy_Percent", "Log_Loss", "Sensitivity", "Specificity", "PPV", "NPV"]
-        log_table = pd.DataFrame(columns=log_cols)
-        log_entry = pd.DataFrame([[self.roc_auc*100, acc*100, balacc*100, ll, sensitivity, specificity, PPV, NPV]], columns=log_cols)
-        log_table = log_table._append(log_entry)
-        
         print("")
         print("#"*70)
         print("")
-
-        log_outfile = self.run_prefix + '.testedModel_validationCohort_allCasesControls_performanceMetrics.csv'
-
         print(f"This table below is also logged as {log_outfile} and is in your current working directory...")
         print("#"*70)
         print(log_table)
         print("#"*70)
-
         print("")
-
-        log_table.to_csv(log_outfile, index=False)
-
-        self.log_table = log_table
-
-        return log_table
-    

--- a/genoml/discrete/supervised/training.py
+++ b/genoml/discrete/supervised/training.py
@@ -13,368 +13,196 @@
 # limitations under the License.
 # ==============================================================================
 
+
 import joblib
-import matplotlib.pyplot as plt
 import pandas as pd
-import seaborn as sns
-import sklearn
-from sklearn import discriminant_analysis, ensemble, linear_model, metrics, model_selection, neighbors, neural_network, svm
-import time
+from pathlib import Path
+from sklearn import discriminant_analysis, ensemble, linear_model, model_selection, neighbors, neural_network, svm
 import xgboost
+import genoml.discrete.utils as discrete_utils
 
 
 # Define the train class
 class train:
+
     def __init__(self, df, run_prefix):
-        #code that will prepare the data
+        # code that will prepare the data
         y = df.PHENO
         X = df.drop(columns=['PHENO'])
-        
-        # Split the data 
-        X_train, X_test, y_train, y_test = model_selection.train_test_split(X, y, test_size=0.3, random_state=42) # 70:30
+
+        # Split the data
+        X_train, X_valid, y_train, y_valid = model_selection.train_test_split(X, y, test_size=0.3, random_state=42)
         IDs_train = X_train.ID
-        IDs_test = X_test.ID
+        IDs_valid = X_valid.ID
         X_train = X_train.drop(columns=['ID'])
-        X_test = X_test.drop(columns=['ID'])
+        X_valid = X_valid.drop(columns=['ID'])
+
+        path = Path(run_prefix).joinpath("Train")
+        if not path.is_dir():
+            path.mkdir()
 
         # Saving the prepped data the other classes will need
         self.df = df
-        self.run_prefix = run_prefix
+        self.run_prefix = path
         self.X_train = X_train
-        self.X_test = X_test
+        self.X_valid = X_valid
         self.y_train = y_train
-        self.y_test = y_test
+        self.y_valid = y_valid
         self.IDs_train = IDs_train
-        self.IDs_test = IDs_test
+        self.IDs_valid = IDs_valid
 
-        # Where the results will be stored 
+        # Where the results will be stored
         self.log_table = None
         self.best_algo = None
         self.algo = None
         self.rfe_df = None
 
-        #The methods we will use
+        ### TODO: Weird results for: SGDClassifier, QuadraticDiscriminantAnalysis
+        ### TODO: MLPClassifier and QuadraticDiscriminantAnalysis do not always converge on training data
+        # The methods we will use
         self.algorithms = [
-        linear_model.LogisticRegression(solver='lbfgs'),
-        ensemble.RandomForestClassifier(n_estimators=100),
-        ensemble.AdaBoostClassifier(),
-        ensemble.GradientBoostingClassifier(),
-        linear_model.SGDClassifier(loss='modified_huber'),
-        svm.SVC(probability=True, gamma='scale'),
-        neural_network.MLPClassifier(),
-        neighbors.KNeighborsClassifier(),
-        discriminant_analysis.LinearDiscriminantAnalysis(),
-        discriminant_analysis.QuadraticDiscriminantAnalysis(),
-        ensemble.BaggingClassifier(),
-        xgboost.XGBClassifier()
+            linear_model.LogisticRegression(solver='lbfgs'),
+            ensemble.RandomForestClassifier(n_estimators=100),
+            ensemble.AdaBoostClassifier(),
+            ensemble.GradientBoostingClassifier(),
+            linear_model.SGDClassifier(loss='modified_huber'),
+            svm.SVC(probability=True, gamma='scale'),
+            neural_network.MLPClassifier(),
+            neighbors.KNeighborsClassifier(),
+            discriminant_analysis.LinearDiscriminantAnalysis(),
+            discriminant_analysis.QuadraticDiscriminantAnalysis(),
+            ensemble.BaggingClassifier(),
+            xgboost.XGBClassifier(),
         ]
-    
-    # Report and data summary you want 
+
+    # Report and data summary you want
     def summary(self):
         print("Your data looks like this (showing the first few lines of the left-most and right-most columns)...")
-        print("#"*70)
+        print("#" * 70)
         print(self.df.describe())
-        print("#"*70)
+        print("#" * 70)
 
-    def compete(self, verbose=False):
-        log_cols=["Algorithm", "AUC_Percent", "Accuracy_Percent", "Balanced_Accuracy_Percent", "Log_Loss", "Sensitivity", "Specificity", "PPV", "NPV", "Runtime_Seconds"]
-        log_table = pd.DataFrame(columns=log_cols)
-
+    def compete(self):
+        self.log_table = []
         for algo in self.algorithms:
-            
-            start_time = time.time()
-            
-            algo.fit(self.X_train, self.y_train)
-            name = algo.__class__.__name__
-
-            print("")
-            print("#"*70)
-            print("")
-            print(name)
-
-            test_predictions = algo.predict_proba(self.X_test)
-            self.test_predictions = test_predictions
-            test_predictions = test_predictions[:, 1]
-            rocauc = metrics.roc_auc_score(self.y_test, test_predictions)
-            print("AUC: {:.4%}".format(rocauc))
-
-            test_predictions = algo.predict(self.X_test)
-            acc = metrics.accuracy_score(self.y_test, test_predictions)
-            print("Accuracy: {:.4%}".format(acc))
-
-            test_predictions = algo.predict(self.X_test)
-            balacc = metrics.balanced_accuracy_score(self.y_test, test_predictions)
-            print("Balanced Accuracy: {:.4%}".format(balacc))
-            
-            CM = metrics.confusion_matrix(self.y_test, test_predictions)
-            TN = CM[0][0]
-            FN = CM[1][0]
-            TP = CM[1][1]
-            FP = CM[0][1]
-            sensitivity = TP/(TP+FN)
-            specificity = TN/(TN+FP)
-            PPV = TP/(TP+FP)
-            NPV = TN/(TN+FN)
-            
-            test_predictions = self.test_predictions
-            #test_predictions = algo.predict_proba(self.X_test)
-            #self.test_predictions = test_predictions
-            ll = metrics.log_loss(self.y_test, test_predictions)
-            print("Log Loss: {:.4}".format(ll))
-            
-            end_time = time.time()
-            elapsed_time = (end_time - start_time)
-            print("Runtime in seconds: {:.4}".format(elapsed_time))
-
-            log_entry = pd.DataFrame([[name, rocauc*100, acc*100, balacc*100, ll, sensitivity, specificity, PPV, NPV, elapsed_time]], columns=log_cols)
-            log_table = log_table._append(log_entry)
-
-        print("#"*70)
+            log_entry = discrete_utils.summary_stats(algo, self.y_valid, self.X_valid)
+            self.log_table.append(log_entry)
+        self.log_table = pd.concat(self.log_table)
+        print("#" * 70)
         print("")
 
-        self.log_table = log_table
-
-        return log_table
-
     def results(self, metric_max):
-        self.metric_max = metric_max 
+        self.metric_max = metric_max
         metric_keys = {
             'AUC': 'AUC_Percent',
             'Balanced_Accuracy': 'Balanced_Accuracy_Percent',
             'Sensitivity': 'Sensitivity',
             'Specificity': 'Specificity'
         }
-        sorted_table = self.log_table.sort_values(metric_keys[self.metric_max], ascending=False)
 
-        # Drop those that have an accuracy less than 50%
-        sorted_table = sorted_table[sorted_table['AUC_Percent'] > 50]
-
-        # Drop those that have a balanced accuracy less than 50%
-        sorted_table = sorted_table[sorted_table['Balanced_Accuracy_Percent'] > 50]
-
-        # Calculate the delta between sensitivity and specificity, and drop those greater than 0.85
-        sorted_table['SENS_SPEC_DELTA'] = sorted_table['Sensitivity'].sub(sorted_table['Specificity'], axis = 0).abs()
-        sorted_table = sorted_table[sorted_table['SENS_SPEC_DELTA'] < 0.85]
-
-        # Drop those with sensitivity 0 or 1
-        sorted_table = sorted_table[(sorted_table['Sensitivity'] != 0.0) & (sorted_table['Sensitivity'] != 1.0)]
-
-        # Drop those with specificity 0 or 1
-        sorted_table = sorted_table[(sorted_table['Specificity'] != 0.0) & (sorted_table['Specificity'] != 1.0)]
-
-        # Reset the index so that we can access the best algorithm at index 0
-        sorted_table = sorted_table.reset_index(drop=True)
+        # Drop those that have an accuracy less than 50%, balanced accuracy less than 50%, delta between sensitivity
+        # and specificity greater than 0.85, sensitivity equal to 0 or 1, or specificity equal to 0 or 1.
+        sorted_table = self.log_table[
+            (self.log_table['AUC_Percent'] > 50)
+            & (self.log_table['Balanced_Accuracy_Percent'] > 50)
+            & (self.log_table['Sensitivity'].sub(self.log_table['Specificity'], axis=0).abs() < 0.85)
+            & (self.log_table['Sensitivity'] != 0.0)
+            & (self.log_table['Sensitivity'] != 1.0)
+            & (self.log_table['Specificity'] != 0.0)
+            & (self.log_table['Specificity'] != 1.0)
+            ]
 
         # If for some reason ALL the algorithms are overfit...
         if sorted_table.empty:
-            print('It seems as though all the algorithms are over-fit in some way or another... We will report the best algorithm based on your chosen metric instead and use that moving forward.')
-            sorted_table = self.log_table.sort_values(metric_keys[self.metric_max], ascending=False)
+            print(
+                'It seems as though all the algorithms are over-fit in some way or another... We will report the best algorithm based on your chosen metric instead and use that moving forward.')
+            sorted_table = self.log_table
 
-        # Get the row with the best algorithm
-        self.best_performing_summary = sorted_table.iloc[0]
+        # Sort the table and reset the index so that we can access the best algorithm at index 0
+        sorted_table = sorted_table.sort_values(metric_keys[self.metric_max], ascending=False)
+        sorted_table = sorted_table.reset_index(drop=True)
 
-        # Get the best algorithm
-        best_algo = sorted_table.at[0, 'Algorithm']
+        # Get the best algorithm's name and AUC.
+        self.best_algo = sorted_table.at[0, 'Algorithm']
+        self.roc_auc = float(sorted_table.at[0, 'AUC_Percent']) * 0.01
 
-        # Get the best algorithm's AUC for the plot later
-        roc_auc_str = sorted_table.at[0, 'AUC_Percent'] 
-
-        # If, for some reason, algorithms report the exact same score, only choose the first one so things don't crash
-        if isinstance(best_algo, list):
-            best_algo = best_algo[0]
-
-        self.best_algo = best_algo
-        roc_auc = float(roc_auc_str)*0.01
-        self.roc_auc = roc_auc
-
-        return best_algo
-
-
-    def AUC(self, save = False):
-        plot_out = self.run_prefix + '.trainedModel_withheldSample_ROC.png'
-
-        # Issue #24: RandomForestClassifier is finicky - can't recalculate moving forward like the other 
-
-        test_predictions = self.algo.predict_proba(self.X_test)
-        self.test_predictions = test_predictions
-        test_predictions = test_predictions[:, 1]
-
-        fpr, tpr, thresholds = metrics.roc_curve(self.y_test, test_predictions)
-        #roc_auc = metrics.auc(fpr, tpr)
-        #roc_auc = metrics.roc_auc_score(self.y_test, test_predictions)
-
-        plt.figure()
-        plt.plot(fpr, tpr, color='purple', label='ROC curve (area = %0.2f)' % self.roc_auc)
-        plt.plot([0, 1], [0, 1], color='cyan', linestyle='--', label='Chance (area = %0.2f)' % 0.5)
-        plt.xlim([0.0, 1.0])
-        plt.ylim([0.0, 1.05])
-        plt.xlabel('False positive rate')
-        plt.ylabel('True positive rate')
-        plt.title('Receiver operating characteristic (ROC) - ' + self.best_algo)
-        plt.legend(loc="lower right")
-        if (save):
-            plt.savefig(plot_out, dpi = 600)
-
-        #print()
-        print(f"We are also exporting a ROC curve for you here {plot_out} this is a graphical representation of AUC in the withheld test data for the best performing algorithm.")
-    
-    def export_prob_hist(self):
-        # Exporting withheld test data
-        #test_predicteds_probs = self.algo.predict_proba(self.X_test)
-        test_predicteds_probs = self.test_predictions
-        test_case_probs = test_predicteds_probs[:, 1]
-        test_predicted_cases = self.algo.predict(self.X_test)
-
-        test_case_probs_df = pd.DataFrame(test_case_probs)
-        test_predicted_cases_df = pd.DataFrame(test_predicted_cases)
-        y_test_df = pd.DataFrame(self.y_test)
-        IDs_test_df = pd.DataFrame(self.IDs_test)
-
-        test_out = pd.concat([IDs_test_df.reset_index(), y_test_df.reset_index(drop=True), test_case_probs_df.reset_index(drop=True), test_predicted_cases_df.reset_index(drop=True)], axis = 1, ignore_index=True)
-        test_out.columns=['INDEX','ID',"CASE_REPORTED","CASE_PROBABILITY","CASE_PREDICTED"]
-        test_out = test_out.drop(columns=['INDEX'])
-
-        test_outfile = self.run_prefix + '.trainedModel_withheldSample_Predictions.csv'
-        test_out.to_csv(test_outfile, index=False)
-
-        print("")
-        print(f"Preview of the exported predictions for the withheld test data that has been exported as {test_outfile} these are pretty straight forward.")
-        print("They generally include the sample ID, the previously reported case status (1 = case), the case probability from the best performing algorithm and the predicted label from that algorithm")
-        print("")
-        print("#"*70)
-        print(test_out.head())
-        print("#"*70)
-
-
-        # Exporting training data, which is by nature overfit
-        train_predicteds_probs = self.algo.predict_proba(self.X_train)
-        train_case_probs = train_predicteds_probs[:, 1]
-        train_predicted_cases = self.algo.predict(self.X_train)
-
-        train_case_probs_df = pd.DataFrame(train_case_probs)
-        train_predicted_cases_df = pd.DataFrame(train_predicted_cases)
-        y_train_df = pd.DataFrame(self.y_train)
-        IDs_train_df = pd.DataFrame(self.IDs_train)
-
-        train_out = pd.concat([IDs_train_df.reset_index(), y_train_df.reset_index(drop=True), train_case_probs_df.reset_index(drop=True), train_predicted_cases_df.reset_index(drop=True)], axis = 1, ignore_index=True)
-        train_out.columns=['INDEX','ID',"CASE_REPORTED","CASE_PROBABILITY","CASE_PREDICTED"]
-        train_out = train_out.drop(columns=['INDEX'])
-
-        train_outfile = self.run_prefix + '.trainedModel_trainingSample_Predictions.csv'
-        train_out.to_csv(train_outfile, index=False)
-
-        print("")
-        print(f"Preview of the exported predictions for the training samples which is naturally overfit and exported as {train_outfile} in the similar format as in the withheld test dataset that was just exported.")
-        print("#"*70)
-        print(train_out.head())
-        print("#"*70)
-
-        # Export histograms of probabilities
-        genoML_colors = ["cyan","purple"]
-
-        # Using the withheld sample data 
-        to_plot_df = test_out
-        to_plot_df['percent_probability'] = to_plot_df['CASE_PROBABILITY']*100
-        to_plot_df['Probability (%)'] = to_plot_df['percent_probability'].round(decimals=0)
-        to_plot_df['Reported Status'] = to_plot_df['CASE_REPORTED']
-        to_plot_df['Predicted Status'] = to_plot_df['CASE_PREDICTED']
-
-        to_plot_df.describe()
-
-        # Start plotting
-        sns.displot(data=to_plot_df, x="Probability (%)", hue="Predicted Status", col="Reported Status", kde=True, palette=genoML_colors, alpha=0.2)
-
-        plot_out = self.run_prefix + '.trainedModel_withheldSample_probabilities.png' 
-        plt.savefig(plot_out, dpi=300)
-
-        print(f"We are also exporting probability density plots to the file {plot_out} this is a plot of the probability distributions of being a case, stratified by case and control status in the withheld test samples.")
-
+        # If for some reason algorithms report the exact same score, only choose the first one so things don't crash
+        if isinstance(self.best_algo, list):
+            self.best_algo = self.best_algo[0]
 
     def export_model(self):
-        best_algo = self.best_algo
-
-        if best_algo == 'LogisticRegression':
-            algo = getattr(sklearn.linear_model, best_algo)()
-
-        elif best_algo == 'SGDClassifier':
-            algo = getattr(sklearn.linear_model, best_algo)(loss='modified_huber')
-
-        elif (best_algo == 'RandomForestClassifier') or (best_algo == 'AdaBoostClassifier') or (best_algo == 'GradientBoostingClassifier') or  (best_algo == 'BaggingClassifier'):
-            algo = getattr(sklearn.ensemble, best_algo)()
-
-        elif best_algo == 'SVC':
-            algo = getattr(sklearn.svm, best_algo)(probability=True)
-
-        elif best_algo == 'ComplementNB':
-            algo = getattr(sklearn.naive_bayes, best_algo)()
-
-        elif best_algo == 'MLPClassifier':
-            algo = getattr(sklearn.neural_network, best_algo)()
-
-        elif best_algo == 'XGBClassifier':
-            algo = getattr(xgboost, best_algo)()
-
-        elif best_algo == 'KNeighborsClassifier':
-            algo = getattr(sklearn.neighbors, best_algo)()
-
-        elif (best_algo == 'LinearDiscriminantAnalysis') or (best_algo == 'QuadraticDiscriminantAnalysis'):
-            algo = getattr(sklearn.discriminant_analysis, best_algo)()
-
+        algo = discrete_utils.get_best_algo(self.best_algo)
         algo.fit(self.X_train, self.y_train)
-        name = algo.__class__.__name__
 
         print("...remember, there are occasionally slight fluctuations in model performance on the same withheld samples...")
-        print("#"*70)
-        print(name)
+        print("#" * 70)
+        print(self.best_algo)
 
-        #test_predictions = algo.predict_proba(self.X_test)
-        test_predictions = self.test_predictions
-        test_predictions = test_predictions[:, 1]
-        rocauc = metrics.roc_auc_score(self.y_test, test_predictions)
-        print("AUC: {:.4%}".format(rocauc))
-
-        test_predictions = algo.predict(self.X_test)
-        acc = metrics.accuracy_score(self.y_test, test_predictions)
-        print("Accuracy: {:.4%}".format(acc))
-
-        ##test_predictions = algo.predict(self.X_test)
-        balacc = metrics.balanced_accuracy_score(self.y_test, test_predictions)
-        print("Balanced Accuracy: {:.4%}".format(balacc))
-
-        #test_predictions = algo.predict_proba(self.X_test)
-        test_predictions = self.test_predictions
-        ll = metrics.log_loss(self.y_test, test_predictions)
-        print("Log Loss: {:.4}".format(ll))
+        discrete_utils.calculate_accuracy_scores(
+            algo,
+            self.y_valid,
+            self.X_valid,
+        )
 
         ### Save it using joblib
-        algo_out = self.run_prefix + '.trainedModel.joblib'
+        algo_out = self.run_prefix.joinpath('trainedModel.joblib')
         joblib.dump(algo, algo_out)
 
-        print("#"*70)
+        print("#" * 70)
         print(f"... this model has been saved as {algo_out} for later use and can be found in your working directory.")
 
         self.algo = algo
 
-        return algo
+    def plot_results(self, save=False):
+        # Issue #24: RandomForestClassifier is finicky - can't recalculate moving forward like the other
+        plot_path = self.run_prefix.joinpath('trainedModel_withheldSample_ROC.png')
+        ground_truth = self.y_valid.values
+        predictions = self.algo.predict(self.X_valid)
+        discrete_utils.ROC(save, plot_path, ground_truth, predictions, plot_label=self.best_algo)
+        discrete_utils.precision_recall_plot(save, plot_path, ground_truth, predictions, plot_label=self.best_algo)
 
-    def save_results(self, run_prefix, algorithmResults = False, bestAlgorithm = False, featureRankings = False):
-        if(algorithmResults):
+    def export_prediction_data(self):
+        discrete_utils.export_prediction_tables(
+            self.algo,
+            self.y_train,
+            self.X_train,
+            self.IDs_train,
+            self.run_prefix.joinpath('trainedModel_withheldSample_trainPredictions.csv'),
+        )
+
+        valid_out = discrete_utils.export_prediction_tables(
+            self.algo,
+            self.y_valid,
+            self.X_valid,
+            self.IDs_valid,
+            self.run_prefix.joinpath('trainedModel_withheldSample_validPredictions.csv'),
+        )
+
+        discrete_utils.export_prob_hist(
+            valid_out,
+            self.run_prefix.joinpath('trainedModel_withheldSample_validProbabilities'),
+        )
+
+    def save_results(self, algorithm_results=False, best_algorithm=False):
+        if algorithm_results:
             log_table = self.log_table
-            log_outfile = self.run_prefix + '.training_withheldSamples_performanceMetrics.csv'
+            log_outfile = self.run_prefix.joinpath('training_withheldSamples_performanceMetrics.csv')
             print(f"""A complete table of the performance metrics can be found at {log_outfile}
             Note that any models that were overfit (if AUC or Balanced Accuracy was 50% or less, or sensitivity/specificity were 1 or 0) were not considered when nominating the best algorithm.""")
 
             print(f"This table below is also logged as {log_outfile} and is in your current working directory...")
-            print("#"*70)
+            print("#" * 70)
             print(log_table)
-            print("#"*70)
+            print("#" * 70)
 
             log_table.to_csv(log_outfile, index=False)
 
-        if(bestAlgorithm):
+        if best_algorithm:
             best_algo = self.best_algo
-            print(f"Based on your withheld samples, the algorithm with the best {self.metric_max} is the {best_algo}... let's save that model for you.")
-            best_algo_name_out = self.run_prefix + ".best_algorithm.txt"
-            file = open(best_algo_name_out,'w')
+            print(
+                f"Based on your withheld samples, the algorithm with the best {self.metric_max} is the {best_algo}... let's save that model for you.")
+            best_algo_name_out = self.run_prefix.joinpath("best_algorithm.txt")
+            file = open(best_algo_name_out, 'w')
             file.write(self.best_algo)
-            file.close() 
+            file.close()
+

--- a/genoml/discrete/supervised/tuning.py
+++ b/genoml/discrete/supervised/tuning.py
@@ -14,12 +14,13 @@
 # ==============================================================================
 
 import joblib
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from pathlib import Path
 import seaborn as sns
 from scipy import stats
 import sklearn
+import matplotlib.pyplot as plt
 from sklearn import discriminant_analysis
 from sklearn import ensemble
 from sklearn import linear_model
@@ -31,274 +32,13 @@ from sklearn import svm
 from time import time
 import xgboost
 
+'''
 class tune():
-    def __init__(self, df, run_prefix, max_iter, cv_count):
-        self.run_prefix = run_prefix
-        self.max_iter = max_iter
-        self.cv_count = cv_count
 
-        self.y_tune = df.PHENO
-        self.IDs_tune = df.ID
-        self.X_tune = df.drop(columns=['PHENO', 'ID'])
-
-        best_algo_name_in = run_prefix + '.best_algorithm.txt'
-        best_algo_df = pd.read_csv(best_algo_name_in, header=None, index_col=False)
-        self.best_algo = str(best_algo_df.iloc[0,0])
-
-        self.algorithms = [
-        linear_model.LogisticRegression(),
-        ensemble.RandomForestClassifier(),
-        ensemble.AdaBoostClassifier(),
-        ensemble.GradientBoostingClassifier(),
-        linear_model.SGDClassifier(loss='modified_huber'),
-        svm.SVC(probability=True),
-        neural_network.MLPClassifier(),
-        neighbors.KNeighborsClassifier(),
-        discriminant_analysis.LinearDiscriminantAnalysis(),
-        discriminant_analysis.QuadraticDiscriminantAnalysis(),
-        ensemble.BaggingClassifier(),
-        xgboost.XGBClassifier()
-        ]
-        self.log_table = None
-        self.best_algo_name_in = None
-        self.best_algo_df = None
-        self.hyperparameters = None
-        self.scoring_metric = None
-        self.cv_tuned = None 
-        self.cv_baseline = None 
-        self.algo = None
-        self.searchCVResults = None
-        self.rand_search = None
-        self.algo_tuned = None
-        self.tune_out = None
-
-    def select_tuning_parameters(self, metric_tune):
-        best_algo = self.best_algo
-        self.metric_tune = metric_tune 
-        
-        if best_algo == 'LogisticRegression':
-            algo = getattr(sklearn.linear_model, best_algo)()
-
-        elif  best_algo == 'SGDClassifier':
-            algo = getattr(sklearn.linear_model, best_algo)(loss='modified_huber')
-
-        elif (best_algo == 'RandomForestClassifier') or (best_algo == 'AdaBoostClassifier') or (best_algo == 'GradientBoostingClassifier') or  (best_algo == 'BaggingClassifier'):
-            algo = getattr(sklearn.ensemble, best_algo)()
-
-        elif best_algo == 'SVC':
-            algo = getattr(sklearn.svm, best_algo)(probability=True, gamma='auto')
-
-        elif best_algo == 'ComplementNB':
-            algo = getattr(sklearn.naive_bayes, best_algo)()
-
-        elif best_algo == 'MLPClassifier':
-            algo = getattr(sklearn.neural_network, best_algo)()
-
-        elif best_algo == 'XGBClassifier':
-            algo = getattr(xgboost, best_algo)()
-
-        elif best_algo == 'KNeighborsClassifier':
-            algo = getattr(sklearn.neighbors, best_algo)()
-
-        elif (best_algo == 'LinearDiscriminantAnalysis') or (best_algo == 'QuadraticDiscriminantAnalysis'):
-            algo = getattr(sklearn.discriminant_analysis, best_algo)()
-
-        self.algo = algo
-
-        if(metric_tune == "AUC"):
-            if best_algo == 'LogisticRegression':
-                hyperparameters = {"penalty": ["l1", "l2"], "C": stats.randint(1, 10)}
-                scoring_metric = metrics.make_scorer(metrics.roc_auc_score, needs_proba=True)
-
-            # Addressing issue #14 - SGDClassifier gets eta < 0 bug at tune
-            elif best_algo == 'SGDClassifier':
-                hyperparameters = { 'alpha': [1e-4, 1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3], 'loss': ['log'], 'penalty': ['l2'], 'n_jobs': [-1] } 
-                scoring_metric = metrics.make_scorer(metrics.roc_auc_score, needs_proba=True)
-
-            elif (best_algo == 'RandomForestClassifier') or (best_algo == 'AdaBoostClassifier') or (best_algo == 'GradientBoostingClassifier') or  (best_algo == 'BaggingClassifier'):
-                hyperparameters = {"n_estimators": stats.randint(1, 1000)}
-                scoring_metric = metrics.make_scorer(metrics.roc_auc_score, needs_proba=True)
-
-            elif best_algo == 'SVC':
-                hyperparameters = {"kernel": ["linear", "poly", "rbf", "sigmoid"], "C": stats.randint(1, 10)}
-                scoring_metric = metrics.make_scorer(metrics.roc_auc_score, needs_proba=True)
-                
-            elif best_algo == 'ComplementNB':
-                hyperparameters = {"alpha": stats.uniform(0,1)}
-                scoring_metric = metrics.make_scorer(metrics.roc_auc_score, needs_proba=True)
-
-            elif best_algo == 'MLPClassifier':
-                hyperparameters = {"alpha": stats.uniform(0,1), "learning_rate": ['constant', 'invscaling', 'adaptive']}
-                scoring_metric = metrics.make_scorer(metrics.roc_auc_score, needs_proba=True)
-
-            elif best_algo == 'XGBClassifier':
-                hyperparameters = {"max_depth": stats.randint(1, 100), "learning_rate": stats.uniform(0,1), "n_estimators": stats.randint(1, 100), "gamma": stats.uniform(0,1)}
-                scoring_metric = metrics.make_scorer(metrics.roc_auc_score, needs_proba=True)
-
-            elif best_algo == 'KNeighborsClassifier':
-                hyperparameters = {"leaf_size": stats.randint(1, 100), "n_neighbors": stats.randint(1, 10)}
-                scoring_metric = metrics.make_scorer(metrics.roc_auc_score, needs_proba=True)
-
-            elif (best_algo == 'LinearDiscriminantAnalysis') or (best_algo == 'QuadraticDiscriminantAnalysis'):
-                hyperparameters = {"tol": stats.uniform(0,1)}
-                scoring_metric = metrics.make_scorer(metrics.roc_auc_score, needs_proba=True)
-            
-        if(metric_tune == "Balanced_Accuracy"):
-            if best_algo == 'LogisticRegression':
-                hyperparameters = {"penalty": ["l1", "l2"], "C": stats.randint(1, 10)}
-                scoring_metric = metrics.make_scorer(metrics.balanced_accuracy_score, needs_proba=False)
-
-            # Addressing issue #14 - SGDClassifier gets eta < 0 bug at tune
-            elif best_algo == 'SGDClassifier':
-                hyperparameters = { 'alpha': [1e-4, 1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3], 'loss': ['log'], 'penalty': ['l2'], 'n_jobs': [-1] } 
-                scoring_metric = metrics.make_scorer(metrics.balanced_accuracy_score, needs_proba=False)
-
-            elif (best_algo == 'RandomForestClassifier') or (best_algo == 'AdaBoostClassifier') or (best_algo == 'GradientBoostingClassifier') or  (best_algo == 'BaggingClassifier'):
-                hyperparameters = {"n_estimators": stats.randint(1, 1000)}
-                scoring_metric = metrics.make_scorer(metrics.balanced_accuracy_score, needs_proba=False)
-
-            elif best_algo == 'SVC':
-                hyperparameters = {"kernel": ["linear", "poly", "rbf", "sigmoid"], "C": stats.randint(1, 10)}
-                scoring_metric = metrics.make_scorer(metrics.balanced_accuracy_score, needs_proba=False)
-                
-            elif best_algo == 'ComplementNB':
-                hyperparameters = {"alpha": stats.uniform(0,1)}
-                scoring_metric = metrics.make_scorer(metrics.balanced_accuracy_score, needs_proba=False)
-
-            elif best_algo == 'MLPClassifier':
-                hyperparameters = {"alpha": stats.uniform(0,1), "learning_rate": ['constant', 'invscaling', 'adaptive']}
-                scoring_metric = metrics.make_scorer(metrics.balanced_accuracy_score, needs_proba=False)
-
-            elif best_algo == 'XGBClassifier':
-                hyperparameters = {"max_depth": stats.randint(1, 100), "learning_rate": stats.uniform(0,1), "n_estimators": stats.randint(1, 100), "gamma": stats.uniform(0,1)}
-                scoring_metric = metrics.make_scorer(metrics.balanced_accuracy_score, needs_proba=False)
-
-            elif best_algo == 'KNeighborsClassifier':
-                hyperparameters = {"leaf_size": stats.randint(1, 100), "n_neighbors": stats.randint(1, 10)}
-                scoring_metric = metrics.make_scorer(metrics.balanced_accuracy_score, needs_proba=False)
-
-            elif (best_algo == 'LinearDiscriminantAnalysis') or (best_algo == 'QuadraticDiscriminantAnalysis'):
-                hyperparameters = {"tol": stats.uniform(0,1)}
-                scoring_metric = metrics.make_scorer(metrics.balanced_accuracy_score, needs_proba=False)
-
-
-        self.hyperparameters = hyperparameters
-        self.scoring_metric = scoring_metric
-            
-        return algo, hyperparameters, scoring_metric
-
-    def apply_tuning_parameters(self):
-        # Randomized search with CV to tune
-        print("Here is a summary of the top 10 iterations of the hyperparameter tuning...")
-        rand_search = model_selection.RandomizedSearchCV(estimator=self.algo, param_distributions=self.hyperparameters, scoring=self.scoring_metric,n_iter=self.max_iter, cv=self.cv_count, n_jobs=-1, random_state=153, verbose=0)
-        start = time()
-        rand_search.fit(self.X_tune, self.y_tune)
-        print("RandomizedSearchCV took %.2f seconds for %d candidates"
-            " parameter iterations." % ((time() - start), self.max_iter))
-
-        self.rand_search = rand_search
-        self.searchCVResults = rand_search.cv_results_
-        self.algo_tuned = rand_search.best_estimator_
-        
-        return rand_search.cv_results_
-
-    def report_tune(self):
-        # Summary of the top 10 iterations of the hyperparameter tune
-        n_top=10
-        results = self.searchCVResults
-        
-        top10_log_cols = ["Model_Rank", "Mean_Validation_Score", "Mean_Standard_Deviation", "Parameters"]
-        top10_log_table = pd.DataFrame(columns=top10_log_cols)
-        
-        for i in range(1, n_top + 1):
-            candidates = np.flatnonzero(results['rank_test_score'] == i)
-            for candidate in candidates:
-                print("Model with Rank: {0}".format(i))
-                print("Mean Validation Score: {0:.3f} (std: {1:.3f})".format(
-                results['mean_test_score'][candidate],
-                results['std_test_score'][candidate]))
-                print("Parameters: {0}".format(results['params'][candidate]))
-                print("")
-                top10_log_entry = pd.DataFrame([[i, results['mean_test_score'][candidate], results['std_test_score'][candidate], results['params'][candidate]]], columns=top10_log_cols)
-                top10_log_table = top10_log_table._append(top10_log_entry)
-
-        log_outfile = self.run_prefix + '.tunedModel_top10Iterations_Summary.csv'
-        top10_log_table.to_csv(log_outfile, index=False)
-
-        print(f"We are exporting a summary table of the top 10 iterations of the hyperparameter tuning step and its parameters here {log_outfile}.")
-
-        return top10_log_table
-
-    def summarize_tune(self):
-    
-        print("Here is the cross-validation summary of your best tuned model hyperparameters...")
-        cv_tuned = model_selection.cross_val_score(estimator=self.rand_search.best_estimator_, X=self.X_tune, y=self.y_tune, scoring=self.scoring_metric, cv=self.cv_count, n_jobs=-1, verbose=0)
-        print("Scores per cross-validation of the metric to be maximized, this scoring metric is AUC or Balanced_Accuracy for discrete phenotypes and explained variance for continuous phenotypes:")
-        print(cv_tuned)
-        print("Mean cross-validation score:")
-        print(cv_tuned.mean())
-        print("Standard deviation of the cross-validation score:")
-        print(cv_tuned.std())
-
-        print("")
-        
-        print("Here is the cross-validation summary of your baseline/default hyperparamters for the same algorithm on the same data...")
-        cv_baseline = model_selection.cross_val_score(estimator=self.algo, X=self.X_tune, y=self.y_tune, scoring=self.scoring_metric, cv=self.cv_count, n_jobs=-1, verbose=0)
-        print("Scores per cross-validation of the metric to be maximized, this scoring metric is AUC or Balanced_Accuracy for discrete phenotypes and explained variance for continuous phenotypes:")
-        print(cv_baseline)
-        print("Mean cross-validation score:")
-        print(cv_baseline.mean())
-        print("Standard deviation of the cross-validation score:")
-        print(cv_baseline.std())
-
-        print("")
-        print("Just a note, if you have a relatively small variance among the cross-validation iterations, there is a higher chance of your model being more generalizable to similar datasets.")
-
-        self.cv_baseline = cv_baseline
-        self.cv_tuned = cv_tuned
-
-        # Output a log table summarizing CV mean scores and standard deviations 
-        summary_CV_log_cols = ["Mean_CV_Score_Baseline", "Standard_Dev_CV_Score_Baseline", "Min_CV_Score_Baseline", "Max_CV_Score_Baseline", "Mean_CV_Score_BestTuned", "Standard_Dev_CV_Score_BestTuned", "Min_CV_Score_BestTuned", "Max_CV_Score_BestTuned"]
-        summary_CV_log_table = pd.DataFrame(columns=summary_CV_log_cols)
-        summary_CV_log_entry = pd.DataFrame([[cv_baseline.mean(), cv_baseline.std(), cv_baseline.min(), cv_baseline.max(), cv_tuned.mean(), cv_tuned.std(), cv_tuned.min(), cv_tuned.max()]], columns=summary_CV_log_cols)
-        summary_CV_log_table = summary_CV_log_table._append(summary_CV_log_entry)
-        log_outfile = self.run_prefix + '.tunedModel_CV_Summary.csv'
-        summary_CV_log_table.to_csv(log_outfile, index=False)
-
-        print(f"We are exporting a summary table of the cross-validation mean score and standard deviation of the baseline vs. best tuned model here {log_outfile}.")
-
-        return summary_CV_log_table
-
-    def compare_performance(self):
-        cv_tuned = self.cv_tuned
-        cv_baseline = self.cv_baseline
-        
-        print("")
-        if cv_baseline.mean() > cv_tuned.mean():
-            print("Based on comparisons of the default parameters to your hyperparameter tuned model, the baseline model actually performed better.")
-            print("Looks like the tune wasn't worth it, we suggest either extending the tune time or just using the baseline model for maximum performance.")
-            print("")
-            print("Let's shut everything down, thanks for trying to tune your model with GenoML.")
-
-            return self.algo
-
-        if cv_baseline.mean() < cv_tuned.mean():
-            print("Based on comparisons of the default parameters to your hyperparameter tuned model, the tuned model actually performed better.")
-            print("Looks like the tune was worth it, we suggest using this model for maximum performance, lets summarize and export this now.")
-            print("In most cases, if opting to use the tuned model, a separate test dataset is a good idea. GenoML has a module to fit models to external data.")
-            
-            algo_tuned = self.rand_search.best_estimator_
-            
-            ### Save it using joblib
-            algo_tuned_out = self.run_prefix + '.tunedModel.joblib'
-            joblib.dump(algo_tuned, algo_tuned_out)
-
-            return algo_tuned
-    
     # def ROC(self):
     #     ### Export the ROC curve
 
-    #     plot_out = self.run_prefix + '.tunedModel_allSample_ROC.png'
+    #     plot_out = self.run_prefix.joinpath('tunedModel_allSample_ROC.png')
 
     #     test_predictions = self.algo_tuned.predict_proba(self.X_tune)
     #     test_predictions = test_predictions[:, 1]
@@ -336,7 +76,7 @@ class tune():
 
         self.tune_out = tune_out
 
-        tune_outfile = self.run_prefix + '.tunedModel_allSample_Predictions.csv'
+        tune_outfile = self.run_prefix.joinpath('tunedModel_allSample_Predictions.csv')
         tune_out.to_csv(tune_outfile, index=False)
         self.tune_out = tune_out
 
@@ -362,8 +102,245 @@ class tune():
         # Start plotting
         sns.displot(data=to_plot_df, x="Probability (%)", hue="Predicted Status", col="Reported Status", kde=True, palette=genoML_colors, alpha=0.2)
 
-        plot_out = self.run_prefix + '.tunedModel_allSample_probabilities.png' 
+        plot_out = self.run_prefix.joinpath('tunedModel_allSample_probabilities.png')
         plt.savefig(plot_out, dpi=300)
 
         print(f"We are also exporting probability density plots to the file {plot_out} this is a plot of the probability distributions of being a case, stratified by case and control status for all samples.")
-        
+'''
+
+import joblib
+import numpy as np
+import pandas as pd
+from pathlib import Path
+from sklearn import metrics, model_selection
+from time import time
+import genoml.discrete.utils as discrete_utils
+
+
+class tune:
+    def __init__(self, df, run_prefix, max_iter, cv_count):
+        path = Path(run_prefix).joinpath("Tune")
+        if not path.is_dir():
+            path.mkdir()
+
+        self.run_prefix = path
+        self.max_iter = max_iter
+        self.cv_count = cv_count
+
+        self.y_tune = df.PHENO
+        self.IDs_tune = df.ID
+        self.X_tune = df.drop(columns=['PHENO', 'ID'])
+
+        best_algo_name_in = Path(run_prefix).joinpath("Train").joinpath('best_algorithm.txt')
+        best_algo_df = pd.read_csv(best_algo_name_in, header=None, index_col=False)
+        self.best_algo = str(best_algo_df.iloc[0, 0])
+
+        self.log_table = None
+        self.best_algo_name_in = None
+        self.best_algo_df = None
+        self.hyperparameters = None
+        self.scoring_metric = None
+        self.cv_tuned = None
+        self.cv_baseline = None
+        self.algo = None
+        self.searchCVResults = None
+        self.rand_search = None
+        self.algo_tuned = None
+        self.tune_out = None
+
+    def select_tuning_parameters(self, metric_tune):
+        best_algo = self.best_algo
+        self.metric_tune = metric_tune
+
+        algo = discrete_utils.get_best_algo(best_algo)
+        hyperparameters = discrete_utils.get_hyperparameters(best_algo)
+
+        if metric_tune == "AUC":
+            scoring_metric = metrics.make_scorer(metrics.roc_auc_score, needs_proba=True, multi_class="ovr")
+        elif metric_tune == "Balanced_Accuracy":
+            scoring_metric = metrics.make_scorer(metrics.balanced_accuracy_score, needs_proba=False)
+
+        self.algo = algo
+        self.hyperparameters = hyperparameters
+        self.scoring_metric = scoring_metric
+
+        return algo, hyperparameters, scoring_metric
+
+    def apply_tuning_parameters(self):
+        # Randomized search with CV to tune
+        print("Here is a summary of the top 10 iterations of the hyperparameter tuning...")
+
+        rand_search = model_selection.RandomizedSearchCV(
+            estimator=self.algo,
+            param_distributions=self.hyperparameters,
+            scoring=self.scoring_metric,
+            n_iter=self.max_iter,
+            cv=self.cv_count,
+            n_jobs=-1,
+            random_state=153,
+            verbose=0,
+        )
+        start = time()
+        rand_search.fit(self.X_tune, self.y_tune)
+        print("RandomizedSearchCV took %.2f seconds for %d candidates parameter iterations." % ((time() - start), self.max_iter))
+        self.rand_search = rand_search
+        self.searchCVResults = rand_search.cv_results_
+        self.algo_tuned = rand_search.best_estimator_
+
+        return rand_search.cv_results_
+
+    def report_tune(self):
+        # Summary of the top 10 iterations of the hyperparameter tune
+        n_top = 10
+        results = self.searchCVResults
+
+        top10_log_cols = ["Model_Rank", "Mean_Validation_Score", "Mean_Standard_Deviation", "Parameters"]
+        log_entries = []
+
+        for rank in range(1, n_top + 1):
+            candidates = np.flatnonzero(results['rank_test_score'] == rank)
+            for candidate in candidates:
+                print("Model with Rank: {0}".format(rank))
+                print("Mean Validation Score: {0:.3f} (std: {1:.3f})".format(
+                    results['mean_test_score'][candidate],
+                    results['std_test_score'][candidate])
+                )
+                print("Parameters: {0}".format(results['params'][candidate]))
+                print("")
+                top10_log_entry = pd.DataFrame(
+                    [[
+                        rank,
+                        results['mean_test_score'][candidate],
+                        results['std_test_score'][candidate],
+                        results['params'][candidate]
+                    ]],
+                    columns=top10_log_cols,
+                )
+                log_entries.append(top10_log_entry)
+
+        top10_log_table = pd.concat(log_entries)
+        log_outfile = self.run_prefix.joinpath('tunedModel_top10Iterations_Summary.csv')
+        top10_log_table.to_csv(log_outfile, index=False)
+
+        print(
+            f"We are exporting a summary table of the top 10 iterations of the hyperparameter tuning step and its parameters here {log_outfile}.")
+
+        return top10_log_table
+
+    def summarize_tune(self):
+        print("Here is the cross-validation summary of your best tuned model hyperparameters...")
+        cv_tuned = model_selection.cross_val_score(
+            estimator=self.rand_search.best_estimator_,
+            X=self.X_tune,
+            y=self.y_tune,
+            scoring=self.scoring_metric,
+            cv=self.cv_count,
+            n_jobs=-1,
+            verbose=0,
+        )
+        print("Scores per cross-validation of the metric to be maximized, this scoring metric is AUC or Balanced_Accuracy for discrete phenotypes and explained variance for continuous phenotypes:")
+        print(cv_tuned)
+        print("Mean cross-validation score:")
+        print(cv_tuned.mean())
+        print("Standard deviation of the cross-validation score:")
+        print(cv_tuned.std())
+
+        print("")
+
+        print("Here is the cross-validation summary of your baseline/default hyperparameters for the same algorithm on the same data...")
+        cv_baseline = model_selection.cross_val_score(
+            estimator=self.algo,
+            X=self.X_tune,
+            y=self.y_tune,
+            scoring=self.scoring_metric,
+            cv=self.cv_count,
+            n_jobs=-1,
+            verbose=0,
+        )
+        print("Scores per cross-validation of the metric to be maximized (AUC or Balanced_Accuracy)")
+        print(cv_baseline)
+        print("Mean cross-validation score:")
+        print(cv_baseline.mean())
+        print("Standard deviation of the cross-validation score:")
+        print(cv_baseline.std())
+
+        print("")
+        print("Just a note, if you have a relatively small variance among the cross-validation iterations, there is a higher chance of your model being more generalizable to similar datasets.")
+
+        self.cv_baseline = cv_baseline
+        self.cv_tuned = cv_tuned
+
+        # Output a log table summarizing CV mean scores and standard deviations
+        summary_CV_log_cols = [
+            "Mean_CV_Score_Baseline",
+            "Standard_Dev_CV_Score_Baseline",
+            "Min_CV_Score_Baseline",
+            "Max_CV_Score_Baseline",
+            "Mean_CV_Score_BestTuned",
+            "Standard_Dev_CV_Score_BestTuned",
+            "Min_CV_Score_BestTuned",
+            "Max_CV_Score_BestTuned",
+        ]
+        summary_CV_log_table = pd.DataFrame(columns=summary_CV_log_cols)
+        summary_CV_log_entry = pd.DataFrame(
+            [[
+                cv_baseline.mean(),
+                cv_baseline.std(),
+                cv_baseline.min(),
+                cv_baseline.max(),
+                cv_tuned.mean(),
+                cv_tuned.std(),
+                cv_tuned.min(),
+                cv_tuned.max(),
+            ]],
+            columns=summary_CV_log_cols,
+        )
+        summary_CV_log_table = pd.concat([summary_CV_log_table, summary_CV_log_entry])
+        log_outfile = self.run_prefix.joinpath('tunedModel_CV_Summary.csv')
+        summary_CV_log_table.to_csv(log_outfile, index=False)
+
+        print(f"We are exporting a summary table of the cross-validation mean score and standard deviation of the baseline vs. best tuned model here {log_outfile}.")
+
+    def compare_performance(self):
+        cv_tuned = self.cv_tuned
+        cv_baseline = self.cv_baseline
+        algo_tuned_out = self.run_prefix.joinpath('tunedModel.joblib')
+
+        print("")
+        if cv_baseline.mean() > cv_tuned.mean():
+            print("Based on comparisons of the default parameters to your hyperparameter tuned model, the baseline model actually performed better.")
+            print("Looks like the tune wasn't worth it, we suggest either extending the tune time or just using the baseline model for maximum performance.")
+            print("")
+            print("Let's shut everything down, thanks for trying to tune your model with GenoML.")
+
+        if cv_baseline.mean() < cv_tuned.mean():
+            print("Based on comparisons of the default parameters to your hyperparameter tuned model, the tuned model actually performed better.")
+            print("Looks like the tune was worth it, we suggest using this model for maximum performance, lets summarize and export this now.")
+            print("In most cases, if opting to use the tuned model, a separate test dataset is a good idea. GenoML has a module to fit models to external data.")
+            algo_tuned = self.rand_search.best_estimator_
+            self.algo = algo_tuned
+
+        joblib.dump(self.algo, algo_tuned_out)
+
+    def plot_results(self, save=False):
+        # Issue #24: RandomForestClassifier is finicky - can't recalculate moving forward like the other
+        plot_path = self.run_prefix.joinpath('tunedModel_withheldSample_ROC.png')
+        self.algo.fit(self.X_tune, self.y_tune)
+        ground_truth = self.y_tune
+        predictions = self.algo.predict(self.X_tune)
+        discrete_utils.ROC(save, plot_path, ground_truth, predictions, plot_label=self.best_algo)
+        discrete_utils.precision_recall_plot(save, plot_path, ground_truth, predictions, plot_label=self.best_algo)
+
+    def export_prediction_data(self):
+        tune_out = discrete_utils.export_prediction_tables(
+            self.algo,
+            self.y_tune,
+            self.X_tune,
+            self.IDs_tune,
+            self.run_prefix.joinpath('tunedModel_withheldSample_testPredictions.csv'),
+        )
+
+        discrete_utils.export_prob_hist(
+            tune_out,
+            self.run_prefix.joinpath('tunedModel_withheldSample_probabilities'),
+        )

--- a/genoml/discrete/utils.py
+++ b/genoml/discrete/utils.py
@@ -1,0 +1,310 @@
+# Copyright 2020 The GenoML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import matplotlib.pyplot as plt
+import pandas as pd
+from scipy import stats
+import sklearn
+from sklearn import metrics
+import seaborn as sns
+import time
+import xgboost
+
+
+def ROC(save, plot_path, ground_truth, predictions, plot_label="Test Dataset"):
+    plt.figure()
+
+    fpr, tpr, _ = metrics.roc_curve(ground_truth, predictions)
+    roc_auc = metrics.roc_auc_score(ground_truth, predictions)
+
+    plt.plot(fpr, tpr, color='purple', label='ROC curve (area = %0.2f)' % roc_auc)
+    plt.plot([0, 1], [0, 1], color='cyan', linestyle='--', label='Chance (area = %0.2f)' % 0.5)
+
+    plt.xlim([0.0, 1.05])
+    plt.ylim([0.0, 1.05])
+    plt.xlabel('False positive rate')
+    plt.ylabel('True positive rate')
+    plt.title(f'Receiver operating characteristic (ROC) - {plot_label}')
+    plt.legend(loc="lower right")
+    if save:
+        plt.savefig(plot_path, dpi=600)
+        print(f"We are also exporting an ROC curve for you here {plot_path} this is a graphical representation of AUC "
+              f"in the withheld test data for the best performing algorithm.")
+
+
+def precision_recall_plot(save, plot_path, ground_truth, predictions, plot_label="Test Dataset"):
+    plt.figure()
+
+    precision, recall, _ = metrics.precision_recall_curve(ground_truth, predictions)
+    plt.plot(precision, recall, label="Precision-Recall curve")
+
+    plt.xlim([0.0, 1.05])
+    plt.ylim([0.0, 1.05])
+    plt.xlabel("Recall")
+    plt.ylabel("Precision")
+    plt.title(f"Precision vs. Recall Curve - {plot_label}")
+    plt.legend(loc="lower left")
+    if save:
+        plt.savefig(plot_path, dpi=600)
+        print(f"We are also exporting a Precision-Recall plot for you here {plot_path}. This is a graphical "
+              f"representation of the relationship between precision and recall scores in the withheld test data for "
+              f"the best performing algorithm.")
+
+
+def export_prediction_tables(algo, y_vals, x_vals, IDs, output_path):
+    predicted_probs = algo.predict_proba(x_vals)
+    case_probs = predicted_probs[:,1]
+    case_probs_df = pd.DataFrame(case_probs)
+    predicted_probs_df = pd.DataFrame(predicted_probs, dtype=float)
+    predicted_cases_df = predicted_probs_df.idxmax(axis=1)
+    y_vals_df = pd.DataFrame(y_vals)
+    IDs_df = pd.DataFrame(IDs)
+    prediction_df = pd.concat(
+        [
+            IDs_df.reset_index(),
+            y_vals_df.reset_index(drop=True),
+            case_probs_df.reset_index(drop=True),
+            predicted_cases_df.reset_index(drop=True),
+        ],
+        axis=1,
+        ignore_index=True,
+    )
+
+    prediction_df.columns = ['INDEX', 'ID', "CASE_REPORTED", "CASE_PROBABILITY", "CASE_PREDICTED"]
+    prediction_df = prediction_df.drop(columns=['INDEX'])
+    prediction_df.to_csv(output_path, index=False)
+
+    print("")
+    print(f"Preview of the exported predictions for the withheld test data that has been exported as {output_path} "
+          f"these are pretty straight forward.")
+    print("They generally include the sample ID, the previously reported case status, the probabilities for each case "
+          "from the best performing algorithm, and the predicted label from that algorithm")
+    print("")
+    print("#" * 70)
+    print(prediction_df.head())
+    print("#" * 70)
+
+    return prediction_df
+
+
+def export_prob_hist(to_plot_df, plot_path):
+    plt.figure()
+
+    # Using the withheld sample data
+    to_plot_df[f'percent_probability'] = to_plot_df[f'CASE_PROBABILITY'] * 100
+    to_plot_df[f'Probability (%)'] = to_plot_df[f'percent_probability'].round(decimals=0)
+    to_plot_df['Reported Status'] = to_plot_df['CASE_REPORTED']
+    to_plot_df['Predicted Status'] = to_plot_df['CASE_PREDICTED']
+
+    to_plot_df.describe()
+
+    # Start plotting
+    sns.histplot(
+        data=to_plot_df,
+        x=f"Probability (%)",
+        hue="Predicted Status",
+        kde=True,
+        alpha=0.2,
+        multiple='dodge',
+    )
+    path = f"{plot_path}.png"
+    plt.savefig(path, dpi=300)
+    plt.clf()
+    print(f"We are also exporting probability density plots to the file {path} this is a plot of the probability "
+          f"distributions for each case, stratified by case status in the withheld test samples.")
+
+
+def get_hyperparameters(best_algo):
+    if best_algo == 'LogisticRegression':
+        hyperparameters = {
+            "penalty": ["l1", "l2"],
+            "C": stats.randint(1, 10),
+        }
+
+    elif best_algo == 'SGDClassifier':
+        hyperparameters = {
+            'alpha': [1e-4, 1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3],
+            'loss': ['log_loss'],
+            'penalty': ['l2'],
+            'n_jobs': [-1],
+        }
+
+    elif best_algo in ('RandomForestClassifier', 'AdaBoostClassifier', 'GradientBoostingClassifier', 'BaggingClassifier'):
+        hyperparameters = {
+            "n_estimators": stats.randint(1, 1000),
+        }
+
+    elif best_algo == 'SVC':
+        hyperparameters = {
+            "kernel": ["linear", "poly", "rbf", "sigmoid"],
+            "C": stats.randint(1, 10),
+        }
+
+    elif best_algo == 'ComplementNB':
+        hyperparameters = {
+            "alpha": stats.uniform(0, 1),
+        }
+
+    elif best_algo == 'MLPClassifier':
+        hyperparameters = {
+            "alpha": stats.uniform(0, 1),
+            "learning_rate": ['constant', 'invscaling', 'adaptive'],
+        }
+
+    elif best_algo == 'XGBClassifier':
+        hyperparameters = {
+            "max_depth": stats.randint(1, 100),
+            "learning_rate": stats.uniform(0, 1),
+            "n_estimators": stats.randint(1, 100),
+            "gamma": stats.uniform(0, 1),
+        }
+
+    elif best_algo == 'KNeighborsClassifier':
+        hyperparameters = {
+            "leaf_size": stats.randint(1, 100),
+            "n_neighbors": stats.randint(1, 10),
+        }
+
+    elif best_algo in ('LinearDiscriminantAnalysis', 'QuadraticDiscriminantAnalysis'):
+        hyperparameters = {
+            "tol": stats.uniform(0, 1),
+        }
+
+    return hyperparameters
+
+
+def get_best_algo(best_algo):
+    if best_algo == 'LogisticRegression':
+        algo = getattr(sklearn.linear_model, best_algo)()
+
+    elif best_algo == 'SGDClassifier':
+        algo = getattr(sklearn.linear_model, best_algo)(loss='modified_huber')
+
+    elif best_algo in ('RandomForestClassifier', 'AdaBoostClassifier', 'GradientBoostingClassifier', 'BaggingClassifier'):
+        algo = getattr(sklearn.ensemble, best_algo)()
+
+    elif best_algo == 'SVC':
+        algo = getattr(sklearn.svm, best_algo)(probability=True)
+
+    elif best_algo == 'ComplementNB':
+        algo = getattr(sklearn.naive_bayes, best_algo)()
+
+    elif best_algo == 'MLPClassifier':
+        algo = getattr(sklearn.neural_network, best_algo)()
+
+    elif best_algo == 'XGBClassifier':
+        algo = getattr(xgboost, best_algo)()
+
+    elif best_algo == 'KNeighborsClassifier':
+        algo = getattr(sklearn.neighbors, best_algo)()
+
+    elif best_algo in ('LinearDiscriminantAnalysis', 'QuadraticDiscriminantAnalysis'):
+        algo = getattr(sklearn.discriminant_analysis, best_algo)()
+
+    return algo
+
+
+def summary_stats(algo, y_vals, x_vals):
+
+    log_cols = [
+        "Algorithm",
+        "AUC_Percent",
+        "Accuracy_Percent",
+        "Balanced_Accuracy_Percent",
+        "Log_Loss",
+        "Sensitivity",
+        "Specificity",
+        "PPV",
+        "NPV",
+        "Runtime_Seconds",
+    ]
+
+    name = algo.__class__.__name__
+    print("")
+    print("#" * 70)
+    print("")
+    print(name)
+    start_time = time.time()
+    algo.fit(x_vals, y_vals)
+
+    rocauc, acc, balacc, ll = calculate_accuracy_scores(
+        algo,
+        y_vals,
+        x_vals,
+    )
+
+    end_time = time.time()
+    elapsed_time = (end_time - start_time)
+    print("Runtime in seconds: {:.4}".format(elapsed_time))
+
+    CM = metrics.confusion_matrix(
+        y_vals.values,
+        algo.predict(x_vals),
+    )
+    TN = CM[0][0]
+    FN = CM[1][0]
+    TP = CM[1][1]
+    FP = CM[0][1]
+    sensitivity = TP/(TP+FN)
+    specificity = TN/(TN+FP)
+    PPV = TP/(TP+FP)
+    NPV = TN/(TN+FN)
+
+    log_entry = pd.DataFrame(
+        [[
+            name,
+            rocauc * 100,
+            acc * 100,
+            balacc * 100,
+            ll,
+            sensitivity,
+            specificity,
+            PPV,
+            NPV,
+            elapsed_time,
+        ]],
+        columns=log_cols,
+    )
+
+    return log_entry
+
+
+def calculate_accuracy_scores(algo, y_vals, x_vals):
+
+    rocauc = metrics.roc_auc_score(
+        y_vals,
+        algo.predict(x_vals),
+        multi_class="ovr",
+    )
+    print("AUC: {:.4%}".format(rocauc))
+
+    acc = metrics.accuracy_score(
+        y_vals,
+        algo.predict(x_vals),
+    )
+    print("Accuracy: {:.4%}".format(acc))
+
+    balacc = metrics.balanced_accuracy_score(
+        y_vals.values,
+        algo.predict(x_vals),
+    )
+    print("Balanced Accuracy: {:.4%}".format(balacc))
+
+    ll = metrics.log_loss(
+        y_vals,
+        algo.predict(x_vals),
+    )
+    print("Log Loss: {:.4}".format(ll))
+    return rocauc, acc, balacc, ll

--- a/genoml/preprocessing/harmonizing.py
+++ b/genoml/preprocessing/harmonizing.py
@@ -20,6 +20,7 @@ import sys
 import joblib
 import pandas as pd
 from pandas_plink import read_plink1_bin
+from pathlib import Path
 
 # Define the munging class
 import genoml.dependencies
@@ -29,12 +30,15 @@ class harmonizing:
         
         # Initializing the variables we will use 
         self.test_geno_prefix = test_geno_prefix
-        self.test_out_prefix = test_out_prefix
         self.ref_model_prefix = ref_model_prefix
         self.training_SNPs = training_SNPs
+        test_out_prefix = Path(test_out_prefix).joinpath("Harmonize")
+        if not test_out_prefix.is_dir():
+            test_out_prefix.mkdir()
+        self.test_out_prefix = test_out_prefix
 
-        infile_h5 = ref_model_prefix + ".dataForML.h5"
-        self.df = pd.read_hdf(infile_h5, key = "dataForML")
+        infile_h5 = Path(ref_model_prefix).joinpath("Munge").joinpath("dataForML.h5")
+        self.df = pd.read_hdf(infile_h5, key="dataForML")
 
     def generate_new_PLINK(self):        
         # Show first few lines of the dataframe
@@ -56,10 +60,10 @@ class harmonizing:
         self.X_test = X_test
         self.IDs_test = IDs_test
 
-        # Read in the column of SNPs from the SNP+Allele file read in 
+        # Read in the column of SNPs from the SNP+Allele file read in
         snps_alleles_df = pd.read_csv(self.training_SNPs, header=None)
         snps_only = snps_alleles_df.iloc[:, 0]
-        snps_temp = self.test_out_prefix + '.SNPS_only_toKeep_temp.txt'
+        snps_temp = str(self.test_out_prefix.joinpath('SNPS_only_toKeep_temp.txt'))
         snps_only.to_csv(snps_temp, header=None, index=False)
 
         print(f"A temporary file of SNPs from your reference dataset to keep in your testing dataset has been exported here: {snps_temp}")
@@ -69,7 +73,7 @@ class harmonizing:
 
         # Creating outfile with SNPs
         # Force the allele designations based on the reference dataset
-        plink_outfile = self.test_out_prefix + ".refSNPs_andAlleles"
+        plink_outfile = str(self.test_out_prefix.joinpath("refSNPs_andAlleles"))
         
         print("")
         print(f"Now we will create PLINK binaries where the reference SNPS and alleles will be based off of your file here: {self.training_SNPs}")
@@ -142,7 +146,7 @@ class harmonizing:
         ref_columns_list = self.df.columns.values.tolist()
 
         # Write out the columns to a text file we will use in munge later 
-        ref_cols_outfile = self.test_out_prefix + ".refColsHarmonize_toKeep.txt"
+        ref_cols_outfile = self.test_out_prefix.joinpath("refColsHarmonize_toKeep.txt")
 
         with open(ref_cols_outfile, 'w') as filehandle:
             for col in ref_columns_list:

--- a/genoml/preprocessing/munging.py
+++ b/genoml/preprocessing/munging.py
@@ -40,6 +40,11 @@ class munging:
     ):
         self.pheno_path = pheno_path
 
+        # make output directory if not already there
+        path = Path(run_prefix)
+        if not path.is_dir():
+            path.mkdir()
+            
         path = Path(run_prefix).joinpath("Munge")
         if not path.is_dir():
             path.mkdir()

--- a/genoml2.egg-info/PKG-INFO
+++ b/genoml2.egg-info/PKG-INFO
@@ -3,484 +3,507 @@ Name: genoml2
 Version: 1.0.0b11
 Summary: GenoML is an automated machine learning tool that optimizes basic machine learning pipelines for genomic data.
 Home-page: https://genoml.github.io/
+Download-URL: https://github.com/GenoML/genoml2/archive/v1.0.0-beta.11.tar.gz
 Maintainer: The GenoML Development Team
 Maintainer-email: genoml@googlegroups.com
-License: UNKNOWN
-Download-URL: https://github.com/GenoML/genoml2/archive/v1.0.0-beta.11.tar.gz
-Description: # GenoML 
-        
-        <p align="center">
-          <img width="300" height="300" src="https://github.com/GenoML/genoml2/blob/master/logo.png">
-        </p>
-        
-        [![Downloads](https://static.pepy.tech/personalized-badge/genoml2?period=total&units=international_system&left_color=black&right_color=grey&left_text=Downloads)](https://pepy.tech/project/genoml2)
-        
-        > Updated 2 March 2021: Latest Release on pip! v1.0.0.beta.11
-        
-        # How to Get Started with GenoML
-        
-        
-        ### Introduction
-        GenoML is an Automated Machine Learning (AutoML) for genomics data. In general, use a Linux or Mac with Python >3.5 for best results. **This [repository](https://github.com/GenoML/genoml2) and [pip package](https://pypi.org/project/genoml2/) are under active development!** 
-        
-        This README is a brief look into how to structure arguments and what arguments are available at each phase for the GenoML CLI. 
-        
-        ### Installing + Downloading Example Data 
-        - Install this repository directly from GitHub (from source; master branch)
-        
-        `git clone https://github.com/GenoML/genoml2.git`
-        
-        - Install using pip or upgrade using pip
-        
-        `pip install genoml2`
-        
-        OR
-        
-        `pip install genoml2 --upgrade`
-        
-        - To install the `examples/` directory (~315 KB), you can use SVN (pre-installed on most Macs)
-        
-        `svn export https://github.com/GenoML/genoml2.git/trunk/examples`
-        
-        > Note: When you pip install this package, the examples/ folder is also downloaded! However, if  you still want to download the directory and SVN is not pre-installed, you can download it via Homebrew if you have that installed using `brew install svn` 
-        
-        ### Table of Contents 
-        #### [0. (OPTIONAL) How to Set Up a Virtual Environment via Conda](#0)
-        #### [1. Munging with GenoML](#1)
-        #### [2. Training with GenoML](#2)
-        #### [3. Tuning with GenoML](#3)
-        #### [4. Testing/Validating with GenoML](#4)
-        #### [5. Experimental Features](#5)
-        
-        <a id="0"></a>
-        ## 0. [OPTIONAL] How to Set Up a Virtual Environment via Conda
-        
-        You can create a virtual environment to run GenoML, if you prefer.
-        If you already have the [Anaconda Distribution](https://www.anaconda.com/products/individual#download), this is fairly simple.
-        
-        To create and activate a virtual environment:
-        
-        ```shell
-        # To create a virtual environment
-        conda create -n GenoML python=3.7
-        
-        # To activate a virtual environment
-        conda activate GenoML
-        
-        # To install requirements via pip 
-        pip install -r requirements.txt
-            # If issues installing xgboost from requirements - (3 options)
-                # use Homebrew to 
-                    # xcode-select --install
-                    # brew install gcc@7
-                # conda install -c conda-forge xgboost 
-                # pip install xgboost==0.90
-            # If issues installing umap 
-                # pip install umap-learn 
-        
-        ## MISC
-        # To deactivate the virtual environment
-        # conda deactivate GenoML
-        
-        # To delete your virtual environment
-        # conda env remove -n GenoML
-        ```
-        
-        To install the GenoML in the user's path in a virtual environment, you can do the following:
-        ```shell
-        # Install the package at this path
-        pip install .
-        
-        # MISC
-        	# To save out the environment requirements to a .txt file
-        # pip freeze > requirements.txt
-        
-        	# Removing a conda virtualenv
-        # conda remove --name GenoML --all 
-        ```
-        
-        <a id="1"></a>
-        ## 1. Munging with GenoML
-        
-        Munging with GenoML will, at minimum, do the following: 
-        - Prune your genotypes using PLINK v1.9 (if `--geno` flag is used)
-        - Impute per column using median or mean (can be changed with the `--impute` flag)
-        - Z-scaling of features and removing columns with a std dev = 0 
-        
-        **Required** arguments for GenoML munging are `--prefix` and `--pheno` 
-        - `data` : Is the data `continuous` or `discrete`?
-        - `method`: Do you want to use `supervised` or `unsupervised` machine learning? *(unsupervised currently under development)*
-        - `mode`:  would you like to `munge`, `train`, `tune`, or `test` your model?
-        - `--prefix` : Where would you like your outputs to be saved?
-        - `--pheno` : Where is your phenotype file? This file only has 2 columns, ID in one, and PHENO in the other (0 for controls and 1 for cases)
-        
-        
-        Be sure to have your files formatted the same as the examples, key points being: 
-        - **0=controls and 1=case** in your phenotype file
-        - Your phenotype file consisting **only** of the "ID" and "PHENO" columns
-        - Your sample IDs matching across all files
-        - Your sample IDs not consisting with only integers (add a prefix or suffix to all sample IDs ensuring they are alphanumeric if this is the case prior to running GenoML)  
-        
-        > *Note:* The following examples are for discrete data, but if you substitute following commands with `continuous` instead of discrete, you can preprocess your continuous data!
-        
-        If you would like to munge just with genotypes (in PLINK binary format), the simplest command is the following: 
-        ```shell
-        # Running GenoML munging on discrete data using PLINK genotype binary files and a phenotype file 
-        
-        genoml discrete supervised munge \
-        --prefix outputs/test_discrete_geno \
-        --geno examples/discrete/training \
-        --pheno examples/discrete/training_pheno.csv
-        ```
-        
-        If you would like to control the pruning stringency in genotypes: 
-        ```shell
-        # Running GenoML munging on discrete data using PLINK genotype binary files and a phenotype file 
-        
-        genoml discrete supervised munge \
-        --prefix outputs/test_discrete_geno \
-        --geno examples/discrete/training \
-        --r2_cutoff 0.3 \
-        --pheno examples/discrete/training_pheno.csv
-        ```
-        
-        You can choose to skip pruning your SNPs at this stage by changing the `--skip_prune` flag to "yes" (default is "no")
-        ```shell
-        # Running GenoML munging on discrete data using PLINK genotype binary files and a phenotype file 
-        
-        genoml discrete supervised munge \
-        --prefix outputs/test_discrete_geno \
-        --geno examples/discrete/training \
-        --skip_prune yes \
-        --pheno examples/discrete/training_pheno.csv
-        ```
-        
-        You can choose to impute on `mean` or `median` by modifying the `--impute` flag, like so *(default is median)*:
-        ```shell
-        # Running GenoML munging on discrete data using PLINK genotype binary files and a phenotype file and specifying impute
-        
-        genoml discrete supervised munge \
-        --prefix outputs/test_discrete_geno \
-        --geno examples/discrete/training \
-        --pheno examples/discrete/training_pheno.csv \
-        --impute mean
-        ```
-        
-        If you suspect collinear variables, and think this will be a problem for training the model moving forward, you can use [variance inflation factor](https://www.investopedia.com/terms/v/variance-inflation-factor.asp) (VIF) filtering: 
-        ```shell
-        # Running GenoML munging on discrete data using PLINK genotype binary files and a phenotype file while using VIF to remove multicollinearity 
-        
-        genoml discrete supervised munge \
-        --prefix outputs/test_discrete_geno \
-        --geno examples/discrete/training \
-        --pheno examples/discrete/training_pheno.csv \
-        --vif 5 \
-        --iter 1
-        ```
-        
-        - The `--vif` flag specifies the VIF threshold you would like to use (5 is recommended) 
-        - The number of iterations you'd like to run can be modified with the `--iter` flag (if you have or anticipate many collinear variables, it's a good idea to increase the iterations)
-        
-        Well, what if you had GWAS summary statistics handy, and would like to just use the same SNPs outlined in that file? You can do so by running the following:
-        ```shell
-        # Running GenoML munging on discrete data using PLINK genotype binary files, a phenotype file, and a GWAS summary statistics file 
-        
-        genoml discrete supervised munge \
-        --prefix outputs/test_discrete_geno \
-        --geno examples/discrete/training \
-        --pheno examples/discrete/training_pheno.csv \
-        --gwas examples/discrete/example_GWAS.csv
-        ```
-        > *Note:* When using the GWAS flag, the PLINK binaries will be pruned to include matching SNPs to the GWAS file. 
-        
-        ...and if you wanted to add a p-value cut-off...
-        ```shell
-        # Running GenoML munging on discrete data using PLINK genotype binary files, a phenotype file, and a GWAS summary statistics file with a p-value cut-off 
-        
-        genoml discrete supervised munge \
-        --prefix outputs/test_discrete_geno \
-        --geno examples/discrete/training \
-        --pheno examples/discrete/training_pheno.csv \
-        --gwas examples/discrete/example_GWAS.csv \
-        --p 0.01
-        ```
-        Do you have additional data you would like to incorporate? Perhaps clinical, demographic, or transcriptomics data? If coded and all numerical, these can be added as an `--addit` file by doing the following: 
-        ```shell
-        # Running GenoML munging on discrete data using PLINK genotype binary files, a phenotype file, and an addit file
-        
-        genoml discrete supervised munge \
-        --prefix outputs/test_discrete_geno \
-        --geno examples/discrete/training \
-        --pheno examples/discrete/training_pheno.csv \
-        --addit examples/discrete/training_addit.csv
-        ```
-        You also have the option of not using PLINK binary files if you would like to just preprocess (and then, later train) on a phenotype and addit file by doing the following:
-        ```shell
-        # Running GenoML munging on discrete data using PLINK genotype binary files, a phenotype file, and an addit file
-        
-        genoml discrete supervised munge \
-        --prefix outputs/test_discrete_geno \
-        --pheno examples/discrete/training_pheno.csv \
-        --addit examples/discrete/training_addit.csv
-        ```
-        
-        Are you interested in selecting and ranking your features? If so, you can use the `--feature_selection` flag and specify like so...:
-        ```shell
-        # Running GenoML munging on discrete data using PLINK genotype binary files, a phenotype file, and running feature selection 
-        
-        genoml discrete supervised munge \
-        --prefix outputs/test_discrete_geno \
-        --geno examples/discrete/training \
-        --pheno examples/discrete/training_pheno.csv \
-        --addit examples/discrete/training_addit.csv \
-        --feature_selection 50
-        ```
-        The `--feature_selection` flag uses extraTrees ([classifier](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.ExtraTreesClassifier.html) for discrete data; [regressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.ExtraTreesRegressor.html) for continuous data) to output a `*.approx_feature_importance.txt` file with the features most contributing to your model at the top. 
-        
-        Do you have additional covariates and confounders you would like to adjust for in the munging step prior to training your model and/or would like to reduce your data? To adjust, use the `--adjust_data` flag with the following necessary flags: 
-        - `--adjust_normalize`: Would you like to normalize your final adjusted data? (Default: yes)
-        - `--target_features`: A .txt file, one column, with a list of features to adjust (no header). These should correspond to features in the munged dataset
-        - `--confounders`: A .csv of confounders to adjust for with ID column and header. Numeric, with no missing data and the ID column is mandatory (this can be PCs, for example)
-        
-        To reduce your data prior to adjusting, use the `--umap_reduce yes` flag. This flag will also prompt you for if you want to adjust your data, normalize, and what your target features and confounders might be. We use the [Uniform Manifold Approximation and Projection for Dimension Reduction](https://umap-learn.readthedocs.io/en/latest/) (UMAP) to reduce your data into 2D, adjust, and exports a plot and an adjusted dataframe moving forward. This can be done by running the following: 
-        
-        ```shell
-        # Running GenoML munging on discreate data using PLINK binary files, a phenotype file, using UMAP to reduce dimensions and account for features, and running feature selection
-        
-        genoml discrete supervised munge \
-        --prefix outputs/test_discrete_geno \
-        --geno examples/discrete/training \
-        --pheno examples/discrete/training_pheno.csv \
-        --addit examples/discrete/training_addit.csv \
-        --umap_reduce yes \
-        --adjust_data yes \
-        --adjust_normalize yes \
-        --target_features examples/discrete/to_adjust.txt \
-        --confounders examples/discrete/training_addit_confounder_example.csv \
-        --feature_selection 50 
-        ```
-        Here, the `--confounders` flag takes in a dataset of features that should be accounted for. This is a .csv file with the ID column and header included and is numeric with no missing data. **The ID column is mandatory.** The `--target_features` flag takes in a .txt with a list of features (column names) you are adjusting for.
-        
-        <a id="2"></a>
-        ## 2. Training with GenoML
-        Training with GenoML competes a number of different algorithms and outputs the best algorithm based on a specific metric that can be tweaked using the `--metric_max` flag *(default is AUC)*.
-        
-        **Required** arguments for GenoML are the following: 
-        - `data` : Is the data `continuous` or `discrete`?
-        - `method`: Do you want to use `supervised` or `unsupervised` machine learning? *(unsupervised currently under development)*
-        - `mode`:  would you like to `munge`, `train`, `tune`, or `test` your model?
-        - `--prefix` : Where would you like your outputs to be saved?
-        
-        The most basic command to train your model looks like the following, it looks for the `*.dataForML` file that was generated in the munging step: 
-        ```shell
-        # Running GenoML supervised training after munging on discrete data
-        
-        genoml discrete supervised train \
-        --prefix outputs/test_discrete_geno
-        ```
-        
-        If you would like to determine the best competing algorithm by something other than the AUC, you can do so by changing the `--metric_max` flag (Options include `AUC`, `Balanced_Accuracy`, `Sensitivity`, and `Specificity`) :
-        ```shell
-        # Running GenoML supervised training after munging on discrete data and specifying the metric to maximize by 
-        
-        genoml discrete supervised train \
-        --prefix outputs/test_discrete_geno \
-        --metric_max Sensitivity
-        ```
-        > *Note:* The `--metric_max` flag is only available for discrete datasets.
-        
-        <a id="3"></a>
-        ## 3. Tuning with GenoML
-        
-        The most basic command to tune your model looks like the following, it looks for the file that was generated in the training step: 
-        ```shell
-        # Running GenoML supervised tuning after munging and training on discrete data
-        
-        genoml discrete supervised tune \
-        --prefix outputs/test_discrete_geno
-        ```
-        
-        If you are interested in changing the number of iterations the tuning process goes through by modifying `--max_tune` *(default is 50)*, or the number of cross-validations by modifying `--n_cv` *(default is 5)*, this is what the command would look like: 
-        ```shell
-        # Running GenoML supervised tuning after munging and training on discrete data, modifying the number of iterations and cross-validations 
-        
-        genoml discrete supervised tune \
-        --prefix outputs/test_discrete_geno \
-        --max_tune 10 --n_cv 3
-        ```
-        
-        If you are interested in tuning on another metric other than AUC *(default is AUC)*, you can modify `--metric_tune` (options are `AUC` or `Balanced_Accuracy`) by doing the following: 
-        ```shell
-        # Running GenoML supervised tuning after munging and training on discrete data, modifying the metric to tune by
-        
-        genoml discrete supervised tune \
-        --prefix outputs/test_discrete_geno \
-        --metric_tune Balanced_Accuracy
-        ```
-        
-        <a id="4"></a>
-        ## 4. Testing/Validation with GenoML
-        
-        In order to properly test how your model performs on a dataset it's never seen before (but you start with different PLINK binaries), we have created the harmonization step that will:
-        1. Keep only the same SNPs between your reference dataset and the dataset you are using for validation
-        2. Force the reference alleles in the validation dataset to match your reference dataset
-        3. Export a `.txt` file with the column names from your reference dataset to later use in the munging of your validation dataset 
-        
-        Using GenoML for both your reference dataset and then your validation dataset, the process will look like the following: 
-        
-        1. Munge and train your first dataset
-            	- That will be your “reference” model
-        2. Use the outputs of step 1's munge for your reference model to harmonize your incoming validation dataset
-        3.  Run through harmonization step with your validation dataset
-        4.  Run through munging with your newly harmonized dataset
-        5.  Retrain your reference model with only the matching columns of your unseen data 
-        	- Given the nature of ML algorithms, you cannot test a model on a set of data that does not have identical features
-        6. Test your newly retrained reference model on the unseen data
-        
-        ### Harmonizing your Validation/Test Dataset 
-        
-        **Required** arguments for harmonizing with GenoML are the following: 
-        - `--test_geno_prefix` : What is the prefix of your validation dataset PLINK binaries?
-        - `--test_prefix`: What do you want the output to be named?
-        - `--ref_model_prefix`:  What is the name of the previously GenoML-munged dataset you would like to use as your reference dataset? (Without the `.dataForML.h5` suffix)
-        - `--training_snps_alleles` : What are the SNPs and alleles you would like to use? (This is generated at the end of your previously-GenoML munged dataset with the suffix `variants_and_alleles.tab`)
-        
-        To harmonize your incoming validation dataset to match the SNPs and alleles to your reference dataset, the command would look like the following:
-        
-        ```shell
-        # Running GenoML harmonize
-        
-        genoml harmonize \
-        --test_geno_prefix examples/discrete/validation \
-        --test_prefix outputs/validation_test_discrete_geno \
-        --ref_model_prefix outputs/test_discrete_geno \
-        --training_snps_alleles outputs/test_discrete_geno.variants_and_alleles.tab
-        ```
-        
-        This step will generate: 
-        - a `*_refColsHarmonize_toKeep.txt` file of columns to keep for the next step 
-        - `*_refSNPs_andAlleles.*` PLINK binary files (.bed, .bim, and .fam) that have the SNPs and alleles match your reference dataset
-        
-        Now that you have harmonized your validation dataset to your reference dataset, you can now munge using a command similar to the following:
-        ```shell
-        # Running GenoML munge after GenoML harmonize
-        
-        genoml discrete supervised munge --prefix outputs/validation_test_discrete_geno \
-        --geno outputs/validation_test_discrete_geno_refSNPs_andAlleles \
-        --pheno examples/discrete/validation_pheno.csv \
-        --addit examples/discrete/validation_addit.csv \
-        --ref_cols_harmonize outputs/validation_test_discrete_geno_refColsHarmonize_toKeep.txt
-        ```
-        All munging options discussed above are available at this step, the only difference here is you will add the `--ref_cols_harmonize` flag to include the `*.refColsHarmonize_toKeep.txt` file generated at the end of harmonizing to only keep the same columns that the reference dataset had. 
-        
-        After munging and training your reference model and harmonizing and munging your unseen test data, **you will retrain your reference model to include only matching features**. Given the nature of ML algorithms, you cannot test a model on a set of data that does not have identical features. 
-        
-        To retrain your model appropriately, after munging your test data with the `--ref_cols_harmonize ` flag, a final columns list will be generated at `*.finalHarmonizedCols_toKeep.txt`. This includes all the features that match between your unseen test data and your reference model. Use the `--matching_columns` flag when retraining your reference model to use the appropriate features.
-        
-        When retraining of the reference model is complete, you are ready to test!
-        
-        A step-by-step guide on how to achieve this is listed below:
-        ```shell
-        # 0. MUNGE THE REFERENCE DATASET
-        genoml discrete supervised munge \
-        --prefix outputs/test_discrete_geno \
-        --geno examples/discrete/training \
-        --pheno examples/discrete/training_pheno.csv
-        # Files made: 
-            # outputs/test_discrete_geno.dataForML.h5
-            # outputs/test_discrete_geno.list_features.txt
-            # outputs/test_discrete_geno.variants_and_alleles.tab
-        
-        # 1. TRAIN THE REFERENCE DATASET
-        genoml discrete supervised train \
-        --prefix outputs/test_discrete_geno
-        # Files made: 
-            # outputs/test_discrete_geno.best_algorithm.txt
-            # outputs/test_discrete_geno.trainedModel.joblib
-            # outputs/test_discrete_geno.trainedModel_trainingSample_Predictions.csv
-            # outputs/test_discrete_geno.trainedModel_withheldSample_Predictions.csv
-            # outputs/test_discrete_geno.trainedModel_withheldSample_ROC.png
-            # outputs/test_discrete_geno.trainedModel_withheldSample_probabilities.png
-            # outputs/test_discrete_geno.training_withheldSamples_performanceMetrics.csv
-        
-        # 2. HARMONIZE TEST DATASET IF USING PLINK/GENOTYPES
-        genoml harmonize \
-        --test_geno_prefix examples/discrete/validation \
-        --test_prefix outputs/validation_test_discrete_geno \
-        --ref_model_prefix outputs/test_discrete_geno \
-        --training_snps_alleles outputs/test_discrete_geno.variants_and_alleles.tab
-        # Files made: 
-            # outputs/validation_test_discrete_geno.refColsHarmonize_toKeep.txt
-            # outputs/validation_test_discrete_geno.refSNPs_andAlleles.bed
-            # outputs/validation_test_discrete_geno.refSNPs_andAlleles.bim
-            # outputs/validation_test_discrete_geno.refSNPs_andAlleles.fam
-        
-        # 3. MUNGE THE TEST DATASET ON REFERENCE MODEL COLUMNS
-        genoml discrete supervised munge \
-        --prefix outputs/validation_test_discrete_geno \
-        --geno outputs/validation_test_discrete_geno.refSNPs_andAlleles \
-        --pheno examples/discrete/validation_pheno.csv \
-        --addit examples/discrete/validation_addit.csv \
-        --ref_cols_harmonize outputs/validation_test_discrete_geno.refColsHarmonize_toKeep.txt
-        # Files made: 
-            # outputs/validation_test_discrete_geno.finalHarmonizedCols_toKeep.txt
-            # outputs/validation_test_discrete_geno.list_features.txt
-            # outputs/test_discrete_geno.variants_and_alleles.tab
-            # outputs/validation_test_discrete_geno.dataForML.h5
-        
-        # 4. RETRAIN REFERENCE MODEL ON INTERSECTING COLUMNS BETWEEN REFERENCE AND TEST
-        genoml discrete supervised train \
-        --prefix outputs/test_discrete_geno \
-        --matching_columns outputs/validation_test_discrete_geno.finalHarmonizedCols_toKeep.txt
-        # Note: This replaces the trained model you made in step 1! 
-        # Files made: 
-            # outputs/test_discrete_geno.best_algorithm.txt
-            # outputs/test_discrete_geno.trainedModel.joblib
-            # outputs/test_discrete_geno.trainedModel_trainingSample_Predictions.csv
-            # outputs/test_discrete_geno.trainedModel_withheldSample_Predictions.csv
-            # outputs/test_discrete_geno.trainedModel_withheldSample_ROC.png
-            # outputs/test_discrete_geno.trainedModel_withheldSample_probabilities.png
-            # outputs/test_discrete_geno.training_withheldSamples_performanceMetrics.csv
-        
-        # OPTIONAL: TUNING YOUR RETRAINED REFERENCE MODEL ON INTERSECTING COLUMNS BETWEEN REFERENCE AND TEST
-        genoml discrete supervised tune \
-        --prefix outputs/test_discrete_geno \
-        --matching_columns outputs/validation_test_discrete_geno.finalHarmonizedCols_toKeep.txt
-        
-        # 5. TEST RETRAINED REFERENCE MODEL OR TUNED MODEL ON UNSEEN DATA
-        genoml discrete supervised test \
-        --prefix outputs/validation_test_discrete_geno \
-        --test_prefix outputs/validation_test_discrete_geno \
-        --ref_model_prefix outputs/test_discrete_geno.trainedModel
-            # If testing a tuned model, change suffix from .trainedModel to .tunedModel
-        # Files made: 
-            # outputs/validation_test_discrete_geno.testedModel_allSample_predictions.csv
-            # outputs/validation_test_discrete_geno.testedModel_allSample_probabilities.png
-            # outputs/validation_test_discrete_geno.testedModel_allSample_ROC.png
-            # outputs/validation_test_discrete_geno.testedModel_allSamples_performanceMetrics.csv
-        ```
-        
-        > *Note:* When munging the test dataset on the reference model columns using the --ref_cols_harmonize, be sure not to include the --feature_selection flag, as you have already specified the columns to keep moving forward.
-        
-        <a id="5"></a>
-        ## 5. Experimental Features
-        **UNDER ACTIVE DEVELOPMENT** 
-        
-        Planned experimental features include, but are not limited to:
-        - Unsupervised munging, training, tuning, and testing
-        -  GWAS QC and Pipeline
-        -  Network analyses
-        -  Meta-learning
-        -  Federated learning
-        -  Biobank-scale support
-        -  Cross-silo checks for genetic duplicates
-        -  Outlier detection
-        -  ...?
-        
-Platform: UNKNOWN
 Classifier: Development Status :: 4 - Beta
 Classifier: Programming Language :: Python :: 3.6
 Classifier: License :: OSI Approved :: Apache Software License
 Classifier: Operating System :: OS Independent
 Requires-Python: >=3.6
 Description-Content-Type: text/markdown
+License-File: LICENSE
+Requires-Dist: joblib
+Requires-Dist: matplotlib
+Requires-Dist: numpy
+Requires-Dist: tables
+Requires-Dist: pandas
+Requires-Dist: pandas_plink
+Requires-Dist: requests
+Requires-Dist: scikit-learn
+Requires-Dist: scipy
+Requires-Dist: seaborn
+Requires-Dist: statsmodels
+Requires-Dist: xgboost==2.0.3
+Requires-Dist: umap-learn
+
+# GenoML 
+
+<p align="center">
+  <img width="300" height="300" src="https://github.com/GenoML/genoml2/blob/master/logo.png">
+</p>
+
+[![Downloads](https://static.pepy.tech/personalized-badge/genoml2?period=total&units=international_system&left_color=black&right_color=grey&left_text=Downloads)](https://pepy.tech/project/genoml2)
+
+> Updated 2 March 2021: Latest Release on pip! v1.0.0.beta.11
+
+# How to Get Started with GenoML
+
+
+### Introduction
+[GenoML (**Geno**mics + **M**achine **L**earning)](https://genoml.com) is an automated Machine Learning (autoML) for genomics data. In general, use a Linux or Mac with Python >3.5 for best results. **This [repository](https://github.com/GenoML/genoml2) and [pip package](https://pypi.org/project/genoml2/) are under active development!** 
+
+This README is a brief look into how to structure arguments and what arguments are available at each phase for the GenoML CLI. 
+
+If you are using GenoML for your own work, please cite the following papers: 
+- Makarious, M. B., Leonard, H. L., Vitale, D., Iwaki, H., Saffo, D., Sargent, L., ... & Faghri, F. (2021). GenoML: Automated Machine Learning for Genomics. arXiv preprint arXiv:2103.03221
+- Makarious, M. B., Leonard, H. L., Vitale, D., Iwaki, H., Sargent, L., Dadu, A., ... & Nalls, M. A. (2021). Multi-Modality Machine Learning Predicting Parkinson’s Disease. bioRxiv.
+
+### Installing + Downloading Example Data 
+- Install this repository directly from GitHub (from source; master branch)
+
+`git clone https://github.com/GenoML/genoml2.git`
+
+- Install using pip or upgrade using pip
+
+`pip install genoml2`
+
+OR
+
+`pip install genoml2 --upgrade`
+
+- To install the `examples/` directory (~315 KB), you can use SVN (pre-installed on most Macs)
+
+`svn export https://github.com/GenoML/genoml2.git/trunk/examples`
+
+> Note: When you pip install this package, the examples/ folder is also downloaded! However, if  you still want to download the directory and SVN is not pre-installed, you can download it via Homebrew if you have that installed using `brew install svn` 
+
+### CHANGELOG
+- 9-OCT-2024: Big changes to output file structure, so now output files go in subdirectories, and prefixes are not required. `README` updated to reflect these changes.
+
+
+### Table of Contents 
+#### [0. (OPTIONAL) How to Set Up a Virtual Environment via Conda](#0)
+#### [1. Munging with GenoML](#1)
+#### [2. Training with GenoML](#2)
+#### [3. Tuning with GenoML](#3)
+#### [4. Testing/Validating with GenoML](#4)
+#### [5. Experimental Features](#5)
+
+<a id="0"></a>
+## 0. [OPTIONAL] How to Set Up a Virtual Environment via Conda
+
+You can create a virtual environment to run GenoML, if you prefer.
+If you already have the [Anaconda Distribution](https://www.anaconda.com/products/individual#download), this is fairly simple.
+
+To create and activate a virtual environment:
+
+```shell
+# To create a virtual environment
+conda create -n GenoML python=3.7
+
+# To activate a virtual environment
+conda activate GenoML
+
+# To install requirements via pip 
+pip install -r requirements.txt
+    # If issues installing xgboost from requirements - (3 options)
+        # use Homebrew to 
+            # xcode-select --install
+            # brew install gcc@7
+        # conda install -c conda-forge xgboost 
+        # pip install xgboost==0.90
+    # If issues installing umap 
+        # pip install umap-learn 
+
+## MISC
+# To deactivate the virtual environment
+# conda deactivate GenoML
+
+# To delete your virtual environment
+# conda env remove -n GenoML
+```
+
+To install the GenoML in the user's path in a virtual environment, you can do the following:
+```shell
+# Install the package at this path
+pip install .
+
+# MISC
+	# To save out the environment requirements to a .txt file
+# pip freeze > requirements.txt
+
+	# Removing a conda virtualenv
+# conda remove --name GenoML --all 
+```
+
+<a id="1"></a>
+## 1. Munging with GenoML
+
+Munging with GenoML will, at minimum, do the following: 
+- Prune your genotypes using PLINK v1.9 (if `--geno` flag is used)
+- Impute per column using median or mean (can be changed with the `--impute` flag)
+- Z-scaling of features and removing columns with a std dev = 0 
+
+**Required** arguments for GenoML munging are `--prefix` and `--pheno` 
+- `data` : Is the data `continuous` or `discrete`?
+- `method`: Do you want to use `supervised` or `unsupervised` machine learning? *(unsupervised currently under development)*
+- `mode`:  would you like to `munge`, `train`, `tune`, or `test` your model?
+- `--prefix` : What is the path to the directory where you would like your outputs to be saved?
+- `--pheno` : Where is your phenotype file? This file only has 2 columns, ID in one, and PHENO in the other (0 for controls and 1 for cases)
+
+
+Be sure to have your files formatted the same as the examples, key points being: 
+- **0=controls and 1=case** in your phenotype file
+- Your phenotype file consisting **only** of the "ID" and "PHENO" columns
+- Your sample IDs matching across all files
+- Your sample IDs not consisting with only integers (add a prefix or suffix to all sample IDs ensuring they are alphanumeric if this is the case prior to running GenoML)
+- Please avoid the use of characters like commas, semi-colons, etc. in the column headers (it is Python after all!)  
+
+> *Note:* The following examples are for discrete data, but if you substitute following commands with `continuous` instead of discrete, you can preprocess your continuous data!
+
+If you would like to munge just with genotypes (in PLINK binary format), the simplest command is the following: 
+```shell
+# Running GenoML munging on discrete data using PLINK genotype binary files and a phenotype file 
+
+genoml discrete supervised munge \
+--prefix outputs \
+--geno examples/discrete/training \
+--pheno examples/discrete/training_pheno.csv
+```
+
+If you would like to control the pruning stringency in genotypes: 
+```shell
+# Running GenoML munging on discrete data using PLINK genotype binary files and a phenotype file 
+
+genoml discrete supervised munge \
+--prefix outputs \
+--geno examples/discrete/training \
+--r2_cutoff 0.3 \
+--pheno examples/discrete/training_pheno.csv
+```
+
+You can choose to skip pruning your SNPs at this stage by changing the `--skip_prune` flag to "yes" (default is "no")
+```shell
+# Running GenoML munging on discrete data using PLINK genotype binary files and a phenotype file 
+
+genoml discrete supervised munge \
+--prefix outputs \
+--geno examples/discrete/training \
+--skip_prune yes \
+--pheno examples/discrete/training_pheno.csv
+```
+
+You can choose to impute on `mean` or `median` by modifying the `--impute` flag, like so *(default is median)*:
+```shell
+# Running GenoML munging on discrete data using PLINK genotype binary files and a phenotype file and specifying impute
+
+genoml discrete supervised munge \
+--prefix outputs \
+--geno examples/discrete/training \
+--pheno examples/discrete/training_pheno.csv \
+--impute mean
+```
+
+If you suspect collinear variables, and think this will be a problem for training the model moving forward, you can use [variance inflation factor](https://www.investopedia.com/terms/v/variance-inflation-factor.asp) (VIF) filtering: 
+```shell
+# Running GenoML munging on discrete data using PLINK genotype binary files and a phenotype file while using VIF to remove multicollinearity 
+
+genoml discrete supervised munge \
+--prefix outputs \
+--geno examples/discrete/training \
+--pheno examples/discrete/training_pheno.csv \
+--vif 5 \
+--iter 1
+```
+
+- The `--vif` flag specifies the VIF threshold you would like to use (5 is recommended) 
+- The number of iterations you'd like to run can be modified with the `--iter` flag (if you have or anticipate many collinear variables, it's a good idea to increase the iterations)
+
+Well, what if you had GWAS summary statistics handy, and would like to just use the same SNPs outlined in that file? You can do so by running the following:
+```shell
+# Running GenoML munging on discrete data using PLINK genotype binary files, a phenotype file, and a GWAS summary statistics file 
+
+genoml discrete supervised munge \
+--prefix outputs \
+--geno examples/discrete/training \
+--pheno examples/discrete/training_pheno.csv \
+--gwas examples/discrete/example_GWAS.csv
+```
+> *Note:* When using the GWAS flag, the PLINK binaries will be pruned to include matching SNPs to the GWAS file. 
+
+...and if you wanted to add a p-value cut-off...
+```shell
+# Running GenoML munging on discrete data using PLINK genotype binary files, a phenotype file, and a GWAS summary statistics file with a p-value cut-off 
+
+genoml discrete supervised munge \
+--prefix outputs \
+--geno examples/discrete/training \
+--pheno examples/discrete/training_pheno.csv \
+--gwas examples/discrete/example_GWAS.csv \
+--p 0.01
+```
+Do you have additional data you would like to incorporate? Perhaps clinical, demographic, or transcriptomics data? If coded and all numerical, these can be added as an `--addit` file by doing the following: 
+```shell
+# Running GenoML munging on discrete data using PLINK genotype binary files, a phenotype file, and an addit file
+
+genoml discrete supervised munge \
+--prefix outputs \
+--geno examples/discrete/training \
+--pheno examples/discrete/training_pheno.csv \
+--addit examples/discrete/training_addit.csv
+```
+You also have the option of not using PLINK binary files if you would like to just preprocess (and then, later train) on a phenotype and addit file by doing the following:
+```shell
+# Running GenoML munging on discrete data using PLINK genotype binary files, a phenotype file, and an addit file
+
+genoml discrete supervised munge \
+--prefix outputs \
+--pheno examples/discrete/training_pheno.csv \
+--addit examples/discrete/training_addit.csv
+```
+
+Are you interested in selecting and ranking your features? If so, you can use the `--feature_selection` flag and specify like so...:
+```shell
+# Running GenoML munging on discrete data using PLINK genotype binary files, a phenotype file, and running feature selection 
+
+genoml discrete supervised munge \
+--prefix outputs \
+--geno examples/discrete/training \
+--pheno examples/discrete/training_pheno.csv \
+--addit examples/discrete/training_addit.csv \
+--feature_selection 50
+```
+The `--feature_selection` flag uses extraTrees ([classifier](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.ExtraTreesClassifier.html) for discrete data; [regressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.ExtraTreesRegressor.html) for continuous data) to output a `*.approx_feature_importance.txt` file with the features most contributing to your model at the top. 
+
+Do you have additional covariates and confounders you would like to adjust for in the munging step prior to training your model and/or would like to reduce your data? To adjust, use the `--adjust_data` flag with the following necessary flags: 
+- `--adjust_normalize`: Would you like to normalize your final adjusted data? (Default: yes)
+- `--target_features`: A .txt file, one column, with a list of features to adjust (no header). These should correspond to features in the munged dataset
+- `--confounders`: A .csv of confounders to adjust for with ID column and header. Numeric, with no missing data and the ID column is mandatory (this can be PCs, for example)
+
+To reduce your data prior to adjusting, use the `--umap_reduce yes` flag. This flag will also prompt you for if you want to adjust your data, normalize, and what your target features and confounders might be. We use the [Uniform Manifold Approximation and Projection for Dimension Reduction](https://umap-learn.readthedocs.io/en/latest/) (UMAP) to reduce your data into 2D, adjust, and exports a plot and an adjusted dataframe moving forward. This can be done by running the following: 
+
+```shell
+# Running GenoML munging on discreate data using PLINK binary files, a phenotype file, using UMAP to reduce dimensions and account for features, and running feature selection
+
+genoml discrete supervised munge \
+--prefix outputs \
+--geno examples/discrete/training \
+--pheno examples/discrete/training_pheno.csv \
+--addit examples/discrete/training_addit.csv \
+--umap_reduce yes \
+--adjust_data yes \
+--adjust_normalize yes \
+--target_features examples/discrete/to_adjust.txt \
+--confounders examples/discrete/training_addit_confounder_example.csv \
+--feature_selection 50 
+```
+Here, the `--confounders` flag takes in a dataset of features that should be accounted for. This is a .csv file with the ID column and header included and is numeric with no missing data. **The ID column is mandatory.** The `--target_features` flag takes in a .txt with a list of features (column names) you are adjusting for.
+
+<a id="2"></a>
+## 2. Training with GenoML
+Training with GenoML competes a number of different algorithms and outputs the best algorithm based on a specific metric that can be tweaked using the `--metric_max` flag *(default is AUC)*.
+
+**Required** arguments for GenoML are the following: 
+- `data` : Is the data `continuous` or `discrete`?
+- `method`: Do you want to use `supervised` or `unsupervised` machine learning? *(unsupervised currently under development)*
+- `mode`:  would you like to `munge`, `train`, `tune`, or `test` your model?
+- `--prefix` : Where would you like your outputs to be saved?
+
+The most basic command to train your model looks like the following, it looks for the `*.dataForML` file that was generated in the munging step: 
+```shell
+# Running GenoML supervised training after munging on discrete data
+
+genoml discrete supervised train \
+--prefix outputs
+```
+
+If you would like to determine the best competing algorithm by something other than the AUC, you can do so by changing the `--metric_max` flag (Options include `AUC`, `Balanced_Accuracy`, `Sensitivity`, and `Specificity`) :
+```shell
+# Running GenoML supervised training after munging on discrete data and specifying the metric to maximize by 
+
+genoml discrete supervised train \
+--prefix outputs \
+--metric_max Sensitivity
+```
+> *Note:* The `--metric_max` flag is only available for discrete datasets.
+
+<a id="3"></a>
+## 3. Tuning with GenoML
+
+The most basic command to tune your model looks like the following, it looks for the file that was generated in the training step: 
+```shell
+# Running GenoML supervised tuning after munging and training on discrete data
+
+genoml discrete supervised tune \
+--prefix outputs
+```
+
+If you are interested in changing the number of iterations the tuning process goes through by modifying `--max_tune` *(default is 50)*, or the number of cross-validations by modifying `--n_cv` *(default is 5)*, this is what the command would look like: 
+```shell
+# Running GenoML supervised tuning after munging and training on discrete data, modifying the number of iterations and cross-validations 
+
+genoml discrete supervised tune \
+--prefix outputs \
+--max_tune 10 --n_cv 3
+```
+
+If you are interested in tuning on another metric other than AUC *(default is AUC)*, you can modify `--metric_tune` (options are `AUC` or `Balanced_Accuracy`) by doing the following: 
+```shell
+# Running GenoML supervised tuning after munging and training on discrete data, modifying the metric to tune by
+
+genoml discrete supervised tune \
+--prefix outputs \
+--metric_tune Balanced_Accuracy
+```
+
+<a id="4"></a>
+## 4. Testing/Validation with GenoML
+
+In order to properly test how your model performs on a dataset it's never seen before (but you start with different PLINK binaries), we have created the harmonization step that will:
+1. Keep only the same SNPs between your reference dataset and the dataset you are using for validation
+2. Force the reference alleles in the validation dataset to match your reference dataset
+3. Export a `.txt` file with the column names from your reference dataset to later use in the munging of your validation dataset 
+
+Using GenoML for both your reference dataset and then your validation dataset, the process will look like the following: 
+
+1. Munge and train your first dataset
+    	- That will be your “reference” model
+2. Use the outputs of step 1's munge for your reference model to harmonize your incoming validation dataset
+3.  Run through harmonization step with your validation dataset
+4.  Run through munging with your newly harmonized dataset
+5.  Retrain your reference model with only the matching columns of your unseen data 
+	- Given the nature of ML algorithms, you cannot test a model on a set of data that does not have identical features
+6. Test your newly retrained reference model on the unseen data
+
+### Harmonizing your Validation/Test Dataset 
+
+**Required** arguments for harmonizing with GenoML are the following: 
+- `--test_geno_prefix` : What is the prefix of your validation dataset PLINK binaries?
+- `--test_prefix`: What is the path to your output directory?
+- `--ref_model_prefix`:  What is the path to the previously GenoML-munged dataset you would like to use as your reference dataset? (This is generated at the end of your previously-GenoML munged dataset at `outputs/Munge/dataForML.h5`)
+- `--training_snps_alleles` : What are the SNPs and alleles you would like to use? (This is generated at the end of your previously-GenoML munged dataset with the suffix `variants_and_alleles.tab`)
+
+To harmonize your incoming validation dataset to match the SNPs and alleles to your reference dataset, the command would look like the following:
+
+```shell
+# Running GenoML harmonize
+
+genoml harmonize \
+--test_geno_prefix examples/discrete/validation \
+--test_prefix outputs \
+--ref_model_prefix outputs \
+--training_snps_alleles outputs/Munge/variants_and_alleles.tab
+```
+
+This step will generate: 
+- a `refColsHarmonize_toKeep.txt` file of columns to keep for the next step 
+- `refSNPs_andAlleles.*` PLINK binary files (.bed, .bim, and .fam) that have the SNPs and alleles match your reference dataset
+- Files are located at `outputs/Harmonize/`
+
+Now that you have harmonized your validation dataset to your reference dataset, you can now munge using a command similar to the following:
+```shell
+# Running GenoML munge after GenoML harmonize
+
+genoml discrete supervised munge 
+--prefix outputs \
+--geno outputs/Harmonize/refSNPs_andAlleles \
+--pheno examples/discrete/validation_pheno.csv \
+--addit examples/discrete/validation_addit.csv \
+--ref_cols_harmonize outputs/Harmonize/refColsHarmonize_toKeep.txt
+```
+All munging options discussed above are available at this step, the only difference here is you will add the `--ref_cols_harmonize` flag to include the `refColsHarmonize_toKeep.txt` file generated at the end of harmonizing to only keep the same columns that the reference dataset had. 
+
+After munging and training your reference model and harmonizing and munging your unseen test data, **you will retrain your reference model to include only matching features**. Given the nature of ML algorithms, you cannot test a model on a set of data that does not have identical features. 
+
+To retrain your model appropriately, after munging your test data with the `--ref_cols_harmonize ` flag, a final columns list will be generated at `outputs/Munge/finalHarmonizedCols_toKeep.txt`. This includes all the features that match between your unseen test data and your reference model. Use the `--matching_columns` flag when retraining your reference model to use the appropriate features.
+
+When retraining of the reference model is complete, you are ready to test!
+
+A step-by-step guide on how to achieve this is listed below:
+```shell
+# 0. MUNGE THE REFERENCE DATASET
+genoml discrete supervised munge \
+--prefix outputs \
+--geno examples/discrete/training \
+--pheno examples/discrete/training_pheno.csv
+# Files made: 
+    # outputs/Munge/dataForML.h5
+    # outputs/Munge/list_features.txt
+    # outputs/Munge/variants_and_alleles.tab
+
+# 1. TRAIN THE REFERENCE DATASET
+genoml discrete supervised train \
+--prefix outputs
+# Files made: 
+    # outputs/Train/best_algorithm.txt
+    # outputs/Train/trainedModel.joblib
+    # outputs/Train/trainedModel_trainingSample_Predictions.csv
+    # outputs/Train/trainedModel_withheldSample_Predictions.csv
+    # outputs/Train/trainedModel_withheldSample_ROC.png
+    # outputs/Train/trainedModel_withheldSample_probabilities.png
+    # outputs/Train/training_withheldSamples_performanceMetrics.csv
+
+# 2. HARMONIZE TEST DATASET IF USING PLINK/GENOTYPES
+genoml harmonize \
+--test_geno_prefix examples/discrete/validation \
+--test_prefix outputs \
+--ref_model_prefix outputs \
+--training_snps_alleles outputs/Harmonize/variants_and_alleles.tab
+# Files made: 
+    # outputs/Harmonize/refColsHarmonize_toKeep.txt
+    # outputs/Harmonize/refSNPs_andAlleles.bed
+    # outputs/Harmonize/refSNPs_andAlleles.bim
+    # outputs/Harmonize/refSNPs_andAlleles.fam
+
+# 3. MUNGE THE TEST DATASET ON REFERENCE MODEL COLUMNS
+genoml discrete supervised munge \
+--prefix outputs \
+--geno outputs/Harmonize/refSNPs_andAlleles \
+--pheno examples/discrete/validation_pheno.csv \
+--addit examples/discrete/validation_addit.csv \
+--ref_cols_harmonize outputs/Harmonize/refColsHarmonize_toKeep.txt
+# Files made: 
+    # outputs/Munge/finalHarmonizedCols_toKeep.txt
+    # outputs/Munge/list_features.txt
+    # outputs/Munge/variants_and_alleles.tab
+    # outputs/Munge/dataForML.h5
+
+# 4. RETRAIN REFERENCE MODEL ON INTERSECTING COLUMNS BETWEEN REFERENCE AND TEST
+genoml discrete supervised train \
+--prefix outputs \
+--matching_columns outputs/Munge/finalHarmonizedCols_toKeep.txt
+# Note: This replaces the trained model you made in step 1! 
+# Files made: 
+    # outputs/Train/best_algorithm.txt
+    # outputs/Train/trainedModel.joblib
+    # outputs/Train/trainedModel_trainingSample_Predictions.csv
+    # outputs/Train/trainedModel_withheldSample_Predictions.csv
+    # outputs/Train/trainedModel_withheldSample_ROC.png
+    # outputs/Train/trainedModel_withheldSample_probabilities.png
+    # outputs/Train/training_withheldSamples_performanceMetrics.csv
+
+# OPTIONAL: TUNING YOUR RETRAINED REFERENCE MODEL ON INTERSECTING COLUMNS BETWEEN REFERENCE AND TEST
+genoml discrete supervised tune \
+--prefix outputs/test_discrete_geno \
+--matching_columns outputs/Munge/finalHarmonizedCols_toKeep.txt
+
+# 5. TEST RETRAINED REFERENCE MODEL OR TUNED MODEL ON UNSEEN DATA
+genoml discrete supervised test \
+--prefix outputs \
+--test_prefix outputs \
+--ref_model_prefix outputs/Train/trainedModel
+    # If testing a tuned model, change path from `/Train/trainedModel` to `/Tune/tunedModel`
+# Files made: 
+    # outputs/Test/testedModel_allSample_predictions.csv
+    # outputs/Test/testedModel_allSample_probabilities.png
+    # outputs/Test/testedModel_allSample_ROC.png
+    # outputs/Test/testedModel_allSamples_performanceMetrics.csv
+```
+
+> *Note:* When munging the test dataset on the reference model columns using the --ref_cols_harmonize, be sure not to include the --feature_selection flag, as you have already specified the columns to keep moving forward.
+
+<a id="5"></a>
+## 5. Experimental Features
+**UNDER ACTIVE DEVELOPMENT** 
+
+Planned experimental features include, but are not limited to:
+- Unsupervised munging, training, tuning, and testing
+-  GWAS QC and Pipeline
+-  Network analyses
+-  Meta-learning
+-  Federated learning
+-  Biobank-scale support
+-  Cross-silo checks for genetic duplicates
+-  Outlier detection
+-  ...?

--- a/genoml2.egg-info/SOURCES.txt
+++ b/genoml2.egg-info/SOURCES.txt
@@ -1,3 +1,4 @@
+LICENSE
 MANIFEST.in
 README.md
 requirements.txt
@@ -22,6 +23,7 @@ genoml/continuous/supervised/testing.py
 genoml/continuous/supervised/training.py
 genoml/continuous/supervised/tuning.py
 genoml/discrete/__init__.py
+genoml/discrete/utils.py
 genoml/discrete/supervised/__init__.py
 genoml/discrete/supervised/testing.py
 genoml/discrete/supervised/training.py

--- a/genoml2.egg-info/entry_points.txt
+++ b/genoml2.egg-info/entry_points.txt
@@ -1,3 +1,2 @@
 [console_scripts]
 genoml = genoml.__main__:handle_main
-

--- a/genoml2.egg-info/requires.txt
+++ b/genoml2.egg-info/requires.txt
@@ -9,4 +9,5 @@ scikit-learn
 scipy
 seaborn
 statsmodels
-xgboost
+xgboost==2.0.3
+umap-learn

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ scikit-learn
 scipy
 seaborn
 statsmodels
-xgboost
+xgboost==2.0.3
 umap-learn

--- a/setup.py
+++ b/setup.py
@@ -15,15 +15,12 @@
 
 import setuptools
 
-# Read the requirements from the requirements.txt file
 with open('requirements.txt') as file:
-    requires = [line.strip() for line in file if not line.startswith('#') and line.strip()]
+    requires = [line.strip() for line in file if not line.startswith('#')]
 
-# Read the long description from the README.md file
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-# Setup function
 setuptools.setup(
     name="genoml2",
     version="1.0.0-beta.11",
@@ -40,13 +37,13 @@ setuptools.setup(
             ['genoml=genoml.__main__:handle_main'],
     },
     packages=setuptools.find_packages(),
-    install_requires=requires,  # Use the requires list from the requirements.txt file
+    install_requires=requires,
     classifiers=[
         "Development Status :: 4 - Beta",
-        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.6",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.9',
+    python_requires='>=3.6',
     package_data={'genoml': ['misc/*']},
 )


### PR DESCRIPTION
Changes to output file structure
- Output files now are generated in subdirectories for each step. 
     - `/Munge`, `/Train`, `/Harmonize`, `/Tune`, `/Test`
- `README` modified to reflect changes, and now includes a CHANGELOG

Changes to discrete and continuous code structure
- File prefixes no longer supported, instead results directories can be named according to analysis. 
   - Ex: If performing `genoml discrete supervised munge` the `--prefix` option should be the path to the desired output directory. Output directory will be created at the munge step if it does not already exist.
- Added utils.py file for discrete functions to consolidate them into one place
- Fixed error where continuous tune wouldn't run due to a missing function argument